### PR TITLE
feat: save supply with no decimal

### DIFF
--- a/lib/godwoken_indexer/worker/refresh_udt_supply.ex
+++ b/lib/godwoken_indexer/worker/refresh_udt_supply.ex
@@ -38,7 +38,6 @@ defmodule GodwokenIndexer.Worker.RefreshUDTSupply do
           supply =
             udt_amounts
             |> Map.fetch!(u.id)
-            |> D.div(Integer.pow(10, u.decimal || 0))
             |> D.add(u.supply || D.new(0))
 
           UDT.changeset(u, %{


### PR DESCRIPTION
因为 eth_call total_supply 返回的supply 是没有经过decimal 处理的，所以默认supply 都是不处理