### PR TITLE
fix: sort by block_number first

### DIFF
--- a/lib/godwoken_indexer/block/sync_worker.ex
+++ b/lib/godwoken_indexer/block/sync_worker.ex
@@ -428,6 +428,7 @@ defmodule GodwokenIndexer.Block.SyncWorker do
   defp update_erc20_balance(token_transfers) do
     address_token_balances =
       TokenBalances.params_set(%{token_transfers_params: token_transfers})
+      |> Enum.sort_by(&Map.fetch(&1, :block_number), &>=/2)
       |> Enum.uniq_by(fn map -> {map[:address_hash], map[:token_contract_address_hash]} end)
 
     balances = BalanceReader.get_balances_of(address_token_balances)


### PR DESCRIPTION
When we fetch multiple block together, we need to uniq the last block's data