### PR TITLE
fix: account_udt not use registry_address

### DIFF
--- a/docs/api/deposit_history.md
+++ b/docs/api/deposit_history.md
@@ -58,7 +58,7 @@ Status: 200 OK
         name: "Nervos Token",
         official_site: null,
         script_hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-        registry_address: null,
+        eth_address: null,
         supply: "240000000000",
         symbol: "CKB",
         transfer_count: 0,

--- a/docs/api/withdrawal_request.md
+++ b/docs/api/withdrawal_request.md
@@ -63,7 +63,7 @@ Status: 200 OK
         name: "Nervos Token",
         official_site: null,
         script_hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-        registry_address: null,
+        eth_address: null,
         supply: "240000000000",
         symbol: "CKB",
         transfer_count: 0,

--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -539,7 +539,7 @@ type RootQueryType {
       gas_limit
       account{
         id
-        registry_address
+        eth_address
       }
       transactions (input: {page: 1, page_size: 2}) {
         type
@@ -555,7 +555,7 @@ type RootQueryType {
       "block": {
         "account": {
           "id": 2,
-          "registry_address": "0x68f5cea51fa6fcfdcc10f6cddcafa13bf6717436"
+          "eth_address": "0x68f5cea51fa6fcfdcc10f6cddcafa13bf6717436"
         },
         "gas_limit": "981000000",
         "gas_used": "95240385",
@@ -867,7 +867,7 @@ type RootQueryType {
       type
       supply
       account{
-        registry_address
+        eth_address
       }
     }
   }
@@ -877,7 +877,7 @@ type RootQueryType {
     "data": {
       "udt": {
         "account": {
-          "registry_address": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
+          "eth_address": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
         },
         "id": "1",
         "name": "Nervos Token",
@@ -901,7 +901,7 @@ type RootQueryType {
       supply
       account{
         eth_address
-        registry_address
+        script_hash
       }
     }
   }
@@ -913,7 +913,7 @@ type RootQueryType {
         {
           "account": {
             "eth_address": null,
-            "registry_address": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
+            "script_hash": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
           },
           "id": "1",
           "name": "Nervos Token",
@@ -923,7 +923,7 @@ type RootQueryType {
         {
           "account": {
             "eth_address": null,
-            "registry_address": "0x21ad25fab1d759da1a419a589c0f36dee5e7fe3d"
+            "script_hash": "0x21ad25fab1d759da1a419a589c0f36dee5e7fe3d"
           },
           "id": "17",
           "name": null,

--- a/lib/godwoken_explorer/account.ex
+++ b/lib/godwoken_explorer/account.ex
@@ -460,27 +460,19 @@ defmodule GodwokenExplorer.Account do
              {:ok, script} <- GodwokenRPC.fetch_script(script_hash) do
           type = switch_account_type(script["code_hash"], script["args"])
 
-          registry_address =
-            if type in [:eth_user, :polyjuice_contract] do
-              {:ok, registry_address} = GodwokenRPC.fetch_registry_address(script_hash)
-              registry_address
-            else
-              nil
-            end
-
           cond do
             type in [:eth_user, :polyjuice_contract] ->
               {Account.script_to_eth_adress(type, script["args"]),
                Account.script_to_eth_adress(type, script["args"])}
 
             type == :polyjuice_creator ->
-              {registry_address, "Deploy Contract"}
+              {script_hash, "Deploy Contract"}
 
             type == :meta_contract ->
-              {registry_address, "Meta Contract"}
+              {script_hash, "Meta Contract"}
 
             type == :eth_addr_reg ->
-              {registry_address, "Eth Address Registry"}
+              {script_hash, "Eth Address Registry"}
 
             type == :udt ->
               {script_hash, script_hash}

--- a/lib/godwoken_explorer/graphql/resolovers/account_udt.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/account_udt.ex
@@ -62,7 +62,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.AccountUDT do
   end
 
   defp do_account_ckbs(address_hashes, ckb_account_id) do
-    %Account{registry_address: token_contract_address_hash} = Repo.get(Account, ckb_account_id)
+    %Account{script_hash: token_contract_address_hash} = Repo.get(Account, ckb_account_id)
 
     if length(address_hashes) > @addresses_max_limit do
       {:error, :too_many_addresses}
@@ -76,7 +76,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.AccountUDT do
       filted_address_hashes =
         Enum.filter(address_hashes, fn address_hash ->
           not Enum.any?(return, fn au ->
-            au.account.registry_address == address_hash or au.account.eth_address == address_hash
+            au.account.eth_address == address_hash
           end)
         end)
 
@@ -93,7 +93,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.AccountUDT do
     with account when not is_nil(account) <-
            Repo.one(
              from a in Account,
-               where: ^address_hash == a.registry_address or ^address_hash == a.eth_address
+               where: ^address_hash == a.eth_address
            ),
          udt_id when is_integer(udt_id) <- UDT.ckb_account_id(),
          {:ok, balance} <- GodwokenRPC.fetch_balance(account.registry_address, udt_id) do
@@ -110,13 +110,11 @@ defmodule GodwokenExplorer.Graphql.Resolvers.AccountUDT do
   defp search_account_udts(address_hashes, token_contract_address_hash) do
     squery =
       from(a in Account)
-      |> where([a], a.eth_address in ^address_hashes or a.registry_address in ^address_hashes)
+      |> where([a], a.eth_address in ^address_hashes)
 
     query =
       from(au in AccountUDT)
-      |> join(:inner, [au], a in subquery(squery),
-        on: au.address_hash in [a.registry_address, a.eth_address]
-      )
+      |> join(:inner, [au], a in subquery(squery), on: au.address_hash == a.eth_address)
       |> select([au, _a], au)
       |> order_by([au], au.updated_at)
       |> distinct([au], [au.address_hash, au.token_contract_address_hash])

--- a/lib/godwoken_explorer/graphql/types/block.ex
+++ b/lib/godwoken_explorer/graphql/types/block.ex
@@ -17,7 +17,7 @@ defmodule GodwokenExplorer.Graphql.Types.Block do
         gas_limit
         account{
           id
-          registry_address
+          eth_address
         }
         transactions (input: {page: 1, page_size: 2}) {
           type
@@ -33,7 +33,7 @@ defmodule GodwokenExplorer.Graphql.Types.Block do
         "block": {
           "account": {
             "id": 2,
-            "registry_address": "0x68f5cea51fa6fcfdcc10f6cddcafa13bf6717436"
+            "eth_address": "0x68f5cea51fa6fcfdcc10f6cddcafa13bf6717436"
           },
           "gas_limit": "981000000",
           "gas_used": "95240385",
@@ -72,7 +72,7 @@ defmodule GodwokenExplorer.Graphql.Types.Block do
         number
         gas_used
         gas_limit
-				producer_address
+    producer_address
         account{
           eth_address
         }

--- a/lib/godwoken_explorer/graphql/types/udt.ex
+++ b/lib/godwoken_explorer/graphql/types/udt.ex
@@ -17,7 +17,7 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
         type
         supply
         account{
-          registry_address
+          eth_address
         }
       }
     }
@@ -27,7 +27,7 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
       "data": {
         "udt": {
           "account": {
-            "registry_address": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
+            "eth_address": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
           },
           "id": "1",
           "name": "Nervos Token",
@@ -56,7 +56,7 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
         supply
         account{
           eth_address
-          registry_address
+          script_hash
         }
       }
     }
@@ -68,7 +68,7 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
           {
             "account": {
               "eth_address": null,
-              "registry_address": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
+              "script_hash": "0xbf1f27daea43849b67f839fd101569daaa321e2c"
             },
             "id": "1",
             "name": "Nervos Token",
@@ -78,7 +78,7 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
           {
             "account": {
               "eth_address": null,
-              "registry_address": "0x21ad25fab1d759da1a419a589c0f36dee5e7fe3d"
+              "script_hash": "0x21ad25fab1d759da1a419a589c0f36dee5e7fe3d"
             },
             "id": "17",
             "name": null,

--- a/lib/godwoken_explorer_web/controllers/api/transfer_controller.ex
+++ b/lib/godwoken_explorer_web/controllers/api/transfer_controller.ex
@@ -6,13 +6,13 @@ defmodule GodwokenExplorerWeb.API.TransferController do
   action_fallback(GodwokenExplorerWeb.API.FallbackController)
 
   def index(conn, %{"eth_address" => "0x" <> _, "udt_address" => "0x" <> _} = params) do
-    with %Account{eth_address: eth_address, registry_address: registry_address} <-
+    with %Account{eth_address: eth_address} <-
            Account |> Repo.get_by(eth_address: String.downcase(params["eth_address"])),
          %Account{eth_address: udt_address} <-
            Repo.get_by(Account, eth_address: String.downcase(params["udt_address"])) do
       results =
         TokenTransfer.list(
-          %{eth_address: eth_address || registry_address, udt_address: udt_address},
+          %{eth_address: eth_address, udt_address: udt_address},
           %{
             page: conn.params["page"] || 1,
             page_size: conn.assigns.page_size
@@ -27,10 +27,10 @@ defmodule GodwokenExplorerWeb.API.TransferController do
   end
 
   def index(conn, %{"eth_address" => "0x" <> _} = params) do
-    with %Account{eth_address: eth_address, registry_address: registry_address} <-
+    with %Account{eth_address: eth_address} <-
            Account.search(String.downcase(params["eth_address"])) do
       results =
-        TokenTransfer.list(%{eth_address: eth_address || registry_address}, %{
+        TokenTransfer.list(%{eth_address: eth_address}, %{
           page: conn.params["page"] || 1,
           page_size: conn.assigns.page_size
         })

--- a/lib/godwoken_explorer_web/controllers/api/udt_controller.ex
+++ b/lib/godwoken_explorer_web/controllers/api/udt_controller.ex
@@ -7,7 +7,7 @@ defmodule GodwokenExplorerWeb.API.UDTController do
   plug JSONAPI.QueryParser, view: UDTView
   action_fallback GodwokenExplorerWeb.API.FallbackController
 
-  # fields[udt]=id,name,symbol,supply,holders,type,registry_address
+  # fields[udt]=id,name,symbol,supply,holders,type,eth_address
   def index(conn, _params) do
     results = UDTView.list(conn.params["type"], conn.params["page"] || 1)
 

--- a/lib/godwoken_explorer_web/views/smart_contract_view.ex
+++ b/lib/godwoken_explorer_web/views/smart_contract_view.ex
@@ -9,7 +9,7 @@ defmodule GodwokenExplorer.SmartContractView do
   def fields do
     [
       :id,
-      :registry_address,
+      :eth_address,
       :name,
       :compiler_version,
       :compiler_file_format,
@@ -20,7 +20,7 @@ defmodule GodwokenExplorer.SmartContractView do
     ]
   end
 
-  def registry_address(smart_contract, _conn) do
+  def eth_address(smart_contract, _conn) do
     smart_contract.account.eth_address
   end
 

--- a/lib/godwoken_explorer_web/views/udt_view.ex
+++ b/lib/godwoken_explorer_web/views/udt_view.ex
@@ -42,7 +42,7 @@ defmodule GodwokenExplorer.UDTView do
     end
   end
 
-  # For udt type account, account_udt token_contract_address_hash is registry_address
+  # For udt type account, account_udt token_contract_address_hash is script_hash
   # For polyjuice_contract type account, account_udt token_contract_address_hash is eth_address
   def holder_count(udt, _conn) do
     token_contract_address_hashes = UDT.list_address_by_udt_id(udt.id)

--- a/lib/godwoken_indexer/block/sync_worker.ex
+++ b/lib/godwoken_indexer/block/sync_worker.ex
@@ -506,7 +506,7 @@ defmodule GodwokenIndexer.Block.SyncWorker do
       if not is_nil(ckb_id) do
         nil
 
-        %Account{registry_address: ckb_contract_address} = Repo.get(Account, ckb_id)
+        %Account{script_hash: ckb_contract_address} = Repo.get(Account, ckb_id)
 
         account_ids =
           polyjuice_params

--- a/lib/godwoken_indexer/block/sync_worker.ex
+++ b/lib/godwoken_indexer/block/sync_worker.ex
@@ -497,15 +497,10 @@ defmodule GodwokenIndexer.Block.SyncWorker do
   end
 
   defp update_ckb_balance(polyjuice_params) do
-    nil
-
     if length(polyjuice_params) > 0 do
       ckb_id = UDT.ckb_account_id()
-      nil
 
       if not is_nil(ckb_id) do
-        nil
-
         %Account{script_hash: ckb_contract_address} = Repo.get(Account, ckb_id)
 
         account_ids =
@@ -536,18 +531,12 @@ defmodule GodwokenIndexer.Block.SyncWorker do
             }
           end)
 
-        nil
-
         {:ok, %GodwokenRPC.Account.FetchedBalances{params_list: import_account_udts}} =
           GodwokenRPC.fetch_balances(params)
-
-        nil
 
         import_account_udts =
           import_account_udts
           |> Enum.map(fn import_au -> import_au |> Map.merge(import_timestamps()) end)
-
-        nil
 
         Repo.insert_all(AccountUDT, import_account_udts,
           on_conflict: {:replace, [:balance, :updated_at]},

--- a/lib/godwoken_indexer/worker/check_contract_code.ex
+++ b/lib/godwoken_indexer/worker/check_contract_code.ex
@@ -10,7 +10,7 @@ defmodule GodwokenIndexer.Worker.CheckContractCode do
     from(a in Account, where: a.type == :polyjuice_contract and is_nil(a.contract_code))
     |> Repo.all()
     |> Enum.each(fn account ->
-      %{"block_number" => "latest", "address" => account.registry_address}
+      %{"block_number" => "latest", "address" => account.eth_address}
       |> GodwokenIndexer.Worker.ImportContractCode.new()
       |> Oban.insert()
     end)

--- a/lib/godwoken_rpc/receipt.ex
+++ b/lib/godwoken_rpc/receipt.ex
@@ -4,7 +4,6 @@ defmodule GodwokenRPC.Receipt do
   [`eth_getTransactionReceipt`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt).
   """
 
-
   import GodwokenRPC, only: [quantity_to_integer: 1]
   alias GodwokenRPC.Logs
 


### PR DESCRIPTION
1. registry_address 只有在使用 fetch_balances 的时候才使用。
2. account_udt 里的token_contract_address_hash 只可能是account 的 script_hash 或者 eth_address. 当这个token 是bridge的时候，是script_hash, 是合约的时候是eth_address
3. account  是 :eth_user 和 :polyjuice_contract 的时候展示 eth_address, 其余的时候展示script_hash, registry_addresss  不会展示