### PR TITLE
chore: refine issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/register-a-general-contract.yml
+++ b/.github/ISSUE_TEMPLATE/register-a-general-contract.yml
@@ -42,6 +42,7 @@ body:
     attributes:
       label: Constructor Arguments
       description: ABI-encoded constructor arguments.
+      render: shell
 
   - type: input
     id: tx-hash
@@ -65,6 +66,7 @@ body:
       required: true
     attributes:
       label: Contract Source Code
+      render: shell
 
   - type: textarea
     id: other-info

--- a/.github/ISSUE_TEMPLATE/register-a-new-bridged-token.yml
+++ b/.github/ISSUE_TEMPLATE/register-a-new-bridged-token.yml
@@ -74,6 +74,7 @@ body:
     attributes:
       label: SUDT Script Arguments
       description: SUDT args of the bridged token on the layer1
+      render: shell
 
   - type: input
     id: contract-address

--- a/.github/ISSUE_TEMPLATE/register-a-new-native-erc20-token.yml
+++ b/.github/ISSUE_TEMPLATE/register-a-new-native-erc20-token.yml
@@ -77,6 +77,7 @@ body:
     attributes:
       label: Constructor Arguments
       description: ABI-encoded constructor arguments.
+      render: shell
 
   - type: input
     id: tx-hash
@@ -100,6 +101,7 @@ body:
       required: true
     attributes:
       label: Contract Source Code
+      render: shell
 
   - type: textarea
     id: other-info


### PR DESCRIPTION
Mark some textareas `render: shell` so the contents will be formatted into code fragments instead of plain texts.