### PR TITLE
fix: add uan field in native erc20 token form

### DIFF
--- a/.github/ISSUE_TEMPLATE/register-a-new-native-erc20-token.yml
+++ b/.github/ISSUE_TEMPLATE/register-a-new-native-erc20-token.yml
@@ -25,6 +25,15 @@ body:
       description: Describe the asset represented by this token.
 
   - type: input
+    id: uan
+    validations:
+      required: false
+    attributes:
+      label: UAN
+      description: The UAN of the token. Following [UAN](https://github.com/nervosnetwork/rfcs/pull/335)
+      placeholder: e.g. WBTC.ckb|fb.eth
+
+  - type: input
     id: max-supply
     validations:
       required: false


### PR DESCRIPTION
There could be some native erc20 tokens bridged from other chains and `UAN` is necessary in these cases, but it's not mandatory for tokens not bridged from otherwhere.