### PR TITLE
(graphql) Feat: enhancement for issue 823, add query condition for udt

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -170,10 +170,6 @@ input AccountCurrentUdtsInput {
   token_contract_address_hash: HashAddress
 }
 
-input AccountIdInput {
-  account_id: Int
-}
-
 input AccountInput {
   """
   address: account address(eth_address)
@@ -1183,38 +1179,6 @@ type RootQueryType {
   blocks(input: BlocksInput = {page: 1, page_size: 10, sort_type: DESC}): [Block]
 
   """
-  function: get udt by contract address
-  
-  request-example:
-  query {
-    get_udt_by_account_id(input: {account_id: 80}){
-      id
-      name
-      type
-      supply
-      account{
-        eth_address
-      }
-    }
-  }
-  
-  {
-    "data": {
-      "get_udt_by_account_id": {
-        "account": {
-          "eth_address": null
-        },
-        "id": "80",
-        "name": "USD Coin",
-        "supply": "9999999999",
-        "type": "BRIDGE"
-      }
-    }
-  }
-  """
-  get_udt_by_account_id(input: AccountIdInput!): Udt
-
-  """
   function: get list of logs by filter or conditions
   
   request-example:
@@ -1877,7 +1841,7 @@ type RootQueryType {
   """
   function: get udt by contract address
   
-  request-example:
+  contract address example:
   query {
     udt(
       input: { contract_address: "0x2275AFE815DE66BEABE7A2C03005537AB843AFB2" }
@@ -1889,10 +1853,38 @@ type RootQueryType {
     }
   }
   
-  result-example:
   {
     "data": {
       "udt": {
+        "contract_address_hash": "0x2275afe815de66beabe7a2c03005537ab843afb2",
+        "id": "36050",
+        "name": "GodwokenToken on testnet_v1",
+        "script_hash": null
+      }
+    }
+  }
+  
+  id example:
+  query {
+    udt(
+      input: {
+        id: 36050
+        contract_address: "0x2275AFE815DE66BEABE7A2C03005537AB843AFB2"
+      }
+    ) {
+      id
+      bridge_account_id
+      name
+      script_hash
+      contract_address_hash
+    }
+  }
+  
+  
+  {
+    "data": {
+      "udt": {
+        "bridge_account_id": null,
         "contract_address_hash": "0x2275afe815de66beabe7a2c03005537ab843afb2",
         "id": "36050",
         "name": "GodwokenToken on testnet_v1",
@@ -2414,7 +2406,9 @@ type Udt {
 }
 
 input UdtInput {
-  contract_address: HashAddress!
+  bridge_account_id: Int
+  contract_address: HashAddress
+  id: Int
 }
 
 input UdtsInput {

--- a/lib/godwoken_explorer/graphql/types/udt.ex
+++ b/lib/godwoken_explorer/graphql/types/udt.ex
@@ -6,7 +6,7 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
     @desc """
     function: get udt by contract address
 
-    request-example:
+    contract address example:
     query {
       udt(
         input: { contract_address: "0x2275AFE815DE66BEABE7A2C03005537AB843AFB2" }
@@ -18,10 +18,38 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
       }
     }
 
-    result-example:
     {
       "data": {
         "udt": {
+          "contract_address_hash": "0x2275afe815de66beabe7a2c03005537ab843afb2",
+          "id": "36050",
+          "name": "GodwokenToken on testnet_v1",
+          "script_hash": null
+        }
+      }
+    }
+
+    id example:
+    query {
+      udt(
+        input: {
+          id: 36050
+          contract_address: "0x2275AFE815DE66BEABE7A2C03005537AB843AFB2"
+        }
+      ) {
+        id
+        bridge_account_id
+        name
+        script_hash
+        contract_address_hash
+      }
+    }
+
+
+    {
+      "data": {
+        "udt": {
+          "bridge_account_id": null,
           "contract_address_hash": "0x2275afe815de66beabe7a2c03005537ab843afb2",
           "id": "36050",
           "name": "GodwokenToken on testnet_v1",
@@ -33,41 +61,6 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
     field :udt, :udt do
       arg(:input, non_null(:udt_input))
       resolve(&Resolvers.UDT.udt/3)
-    end
-
-    @desc """
-    function: get udt by contract address
-
-    request-example:
-    query {
-      get_udt_by_account_id(input: {account_id: 80}){
-        id
-        name
-        type
-        supply
-        account{
-          eth_address
-        }
-      }
-    }
-
-    {
-      "data": {
-        "get_udt_by_account_id": {
-          "account": {
-            "eth_address": null
-          },
-          "id": "80",
-          "name": "USD Coin",
-          "supply": "9999999999",
-          "type": "BRIDGE"
-        }
-      }
-    }
-    """
-    field :get_udt_by_account_id, :udt do
-      arg(:input, non_null(:account_id_input))
-      resolve(&Resolvers.UDT.get_udt_by_account_id/3)
     end
 
     @desc """
@@ -430,11 +423,9 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
   end
 
   input_object :udt_input do
-    field :contract_address, non_null(:hash_address)
-  end
-
-  input_object :account_id_input do
-    field :account_id, :integer
+    field :id, :integer
+    field :bridge_account_id, :integer
+    field :contract_address, :hash_address
   end
 
   input_object :udts_input do


### PR DESCRIPTION
add new query condition for `udt` query

example:
```graphql
query {
  udt(
    input: {
      id: 36050
      contract_address: "0x2275AFE815DE66BEABE7A2C03005537AB843AFB2"
    }
  ) {
    id
    bridge_account_id
    name
    script_hash
    contract_address_hash
  }
}

```

result: 
```graphql
{
  "data": {
    "udt": {
      "bridge_account_id": null,
      "contract_address_hash": "0x2275afe815de66beabe7a2c03005537ab843afb2",
      "id": "36050",
      "name": "GodwokenToken on testnet_v1",
      "script_hash": null
    }
  }
}
```