### PR TITLE
(graphql) fix issue 827 of filtering unexpect null value for query

### DIFF
--- a/lib/godwoken_explorer/graphql/middleware/null_filter.ex
+++ b/lib/godwoken_explorer/graphql/middleware/null_filter.ex
@@ -1,0 +1,27 @@
+defmodule GodwokenExplorer.Graphql.Middleware.NullFilter do
+  @behaviour Absinthe.Middleware
+
+  def call(resolution, _config) do
+    arguments = resolution.arguments
+    input = arguments[:input]
+
+    if is_nil(input) do
+      resolution
+    else
+      new_input = null_filtering(input)
+      %{resolution | arguments: %{arguments | input: new_input}}
+    end
+  end
+
+  defp null_filtering(input) do
+    Enum.reduce(input, input, fn {key, v}, acc ->
+      case v do
+        nil ->
+          Map.drop(acc, [key])
+
+        _ ->
+          acc
+      end
+    end)
+  end
+end

--- a/lib/godwoken_explorer/graphql/resolovers/token_transfer.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/token_transfer.ex
@@ -89,12 +89,6 @@ defmodule GodwokenExplorer.Graphql.Resolvers.TokenTransfer do
           {:transaction_hash, value} ->
             dynamic([tt], ^acc and tt.transaction_hash == ^value)
 
-          # {:from_address, value} ->
-          #   dynamic([tt], ^acc and tt.from_address_hash == ^value)
-
-          # {:to_address, value} ->
-          #   dynamic([tt], ^acc and tt.to_address_hash == ^value)
-
           {:token_contract_address_hash, value} ->
             dynamic([tt], ^acc and tt.token_contract_address_hash == ^value)
 

--- a/lib/godwoken_explorer/graphql/types/token_transfer.ex
+++ b/lib/godwoken_explorer/graphql/types/token_transfer.ex
@@ -1,6 +1,7 @@
 defmodule GodwokenExplorer.Graphql.Types.TokenTransfer do
   use Absinthe.Schema.Notation
   alias GodwokenExplorer.Graphql.Resolvers, as: Resolvers
+  alias GodwokenExplorer.Graphql.Middleware.NullFilter
 
   object :token_transfer_querys do
     @desc """
@@ -152,7 +153,7 @@ defmodule GodwokenExplorer.Graphql.Types.TokenTransfer do
     """
     field :token_transfers, :paginate_token_transfers do
       arg(:input, non_null(:token_transfer_input), default_value: %{})
-
+      middleware(NullFilter)
       resolve(&Resolvers.TokenTransfer.token_transfers/3)
     end
   end


### PR DESCRIPTION
summary:
API server raise internal error when using explicit null value of input fields

env: testnet-stg

error example:
```
query {
  token_transfers(
    input: {
      before: null
      after: null
      token_contract_address_hash: null
      limit: 1
    }
  ) {
    entries {
      amount
      transaction_hash
      log_index
      polyjuice {
        status
      }
      from_address
      to_address
      block {
        number
        timestamp
        status
      }
      udt {
        id
        decimal
        symbol
      }
    }
    metadata {
      total_count
      before
      after
    }
  }
}
```

error result: 
<img width="530" alt="image" src="https://user-images.githubusercontent.com/12268276/182853120-a7493d19-4884-4e6e-8eed-3a8e0ad8f92a.png">



after fix will return:
```
{
  "data": {
    "token_transfers": {
      "entries": [
        {
          "amount": "5000000000000000000",
          "block": {
            "number": 250777,
            "status": "COMMITTED",
            "timestamp": "2022-08-04T12:39:03.500000Z"
          },
          "from_address": "0x19884aec2e463c06f08c3f380568d1a531d3293b",
          "log_index": 0,
          "polyjuice": {
            "status": "SUCCEED"
          },
          "to_address": "0x4e4fa411c6ed5a02889be7b88b9397e93f0e97d3",
          "transaction_hash": "0x19a49b3c83517a84c2102dc89c002dd7206b818c4c04bcfabc55131692adbb24",
          "udt": {
            "decimal": 18,
            "id": "17366",
            "symbol": "XVS"
          }
        }
      ],
      "metadata": {
        "after": "g3QAAAADZAAMYmxvY2tfbnVtYmVyYgAD05lkAAlsb2dfaW5kZXhhAGQAEHRyYW5zYWN0aW9uX2hhc2h0AAAAA2QACl9fc3RydWN0X19kACJFbGl4aXIuR29kd29rZW5FeHBsb3Jlci5DaGFpbi5IYXNoZAAKYnl0ZV9jb3VudGEgZAAFYnl0ZXNtAAAAIBmkmzyDUXqEwhAtyJwALdcga4GMTAS8-rxVExaSrbsk",
        "before": null,
        "total_count": 10000
      }
    }
  }
}
```