### PR TITLE
Fix: fix unregistered smart contact update other data

### DIFF
--- a/lib/godwoken_explorer/smart_contract.ex
+++ b/lib/godwoken_explorer/smart_contract.ex
@@ -36,7 +36,7 @@ defmodule GodwokenExplorer.SmartContract do
   def changeset(smart_contract, attrs) do
     smart_contract
     |> cast(attrs, base_fields())
-    |> validate_required([:name, :contract_source_code, :abi, :account_id])
+    |> validate_required([:account_id])
     |> unsafe_validate_unique(:account_id, Repo)
   end
 

--- a/priv/repo/migrations/20220825070147_alter_smart_contracts_null_requrie_field.exs
+++ b/priv/repo/migrations/20220825070147_alter_smart_contracts_null_requrie_field.exs
@@ -1,0 +1,11 @@
+defmodule GodwokenExplorer.Repo.Migrations.AlterSmartContractsNullRequrieField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:smart_contracts) do
+      modify :name, :string, null: true
+      modify :contract_source_code, :text, null: true
+      modify :abi, :jsonb, null: true
+    end
+  end
+end

--- a/test/graphql/sourcify_test.exs
+++ b/test/graphql/sourcify_test.exs
@@ -18,7 +18,27 @@ defmodule GodwokenExplorer.Graphql.SourcifyTest do
         eth_address: native_udt.contract_address_hash
       )
 
-    [native_udt: native_udt, udt_account: udt_account]
+    unregistered_udt_account = Factory.insert!(:polyjuice_contract_account)
+
+    {:ok, args} =
+      GodwokenExplorer.Chain.Data.cast(
+        "0x01000000060000001600000000000000000000000000000001000000000000000000000000000000"
+      )
+
+    transaction = Factory.insert!(:transaction, args: args)
+
+    _polyjuice =
+      Factory.insert!(:polyjuice,
+        created_contract_address_hash: unregistered_udt_account.eth_address,
+        transaction: transaction
+      )
+
+    [
+      native_udt: native_udt,
+      udt_account: udt_account,
+      unregistered_udt_account: unregistered_udt_account,
+      transaction: transaction
+    ]
   end
 
   test "graphql: sourcify_check_by_addresses  ", %{
@@ -90,6 +110,50 @@ defmodule GodwokenExplorer.Graphql.SourcifyTest do
                "data" => %{
                  "verify_and_update_from_sourcify" => %{
                    "account_id" => ^udt_account_id
+                 }
+               }
+             },
+             json_response(conn, 200)
+           )
+  end
+
+  test "graphql: verify_and_update_from_sourcify unregistered ", %{
+    conn: conn,
+    unregistered_udt_account: unregistered_udt_account,
+    transaction: transaction
+  } do
+    address = unregistered_udt_account.eth_address |> to_string()
+    unregistered_udt_account_id = unregistered_udt_account.id |> to_string()
+    deployment_tx_hash = transaction.eth_hash |> to_string()
+
+    query = """
+    mutation {
+      verify_and_update_from_sourcify(
+        input: { address: "#{address}" }
+      ) {
+        id
+        account_id
+        # contract_source_code
+        # abi
+        compiler_version
+        deployment_tx_hash
+        name
+      }
+    }
+    """
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    assert match?(
+             %{
+               "data" => %{
+                 "verify_and_update_from_sourcify" => %{
+                   "account_id" => ^unregistered_udt_account_id,
+                   "deployment_tx_hash" => ^deployment_tx_hash
                  }
                }
              },


### PR DESCRIPTION
fields with `name`, `abi` and `source code` is required by insert or update to the repo.

so if the smart contract not registered in the sourcify then we can not get the data when insert/update the smart contract with orther fields like `deployment tx hash`

solution:

we add the default value for the require fields 