### PR TITLE
feat: flush poly version cache in admin

### DIFF
--- a/lib/godwoken_explorer/chain/cache/poly_version.ex
+++ b/lib/godwoken_explorer/chain/cache/poly_version.ex
@@ -1,6 +1,6 @@
 defmodule GodwokenExplorer.Chain.Cache.PolyVersion do
   @moduledoc """
-  Cache for block count.
+  Cache for godwoken version.
   """
 
   require Logger

--- a/lib/godwoken_explorer_web/controllers/admin/dashboard_controller.ex
+++ b/lib/godwoken_explorer_web/controllers/admin/dashboard_controller.ex
@@ -1,0 +1,18 @@
+defmodule GodwokenExplorerWeb.Admin.DashboardController do
+  use GodwokenExplorerWeb, :controller
+
+  plug(:put_root_layout, {GodwokenExplorerWeb.LayoutView, "torch.html"})
+  plug(:put_layout, false)
+
+  def index(conn, _) do
+    render(conn, "index.html")
+  end
+
+  def flush_poly_version_cache(conn, _key) do
+    ConCache.delete(:poly_version, :version)
+
+    conn
+    |> put_flash(:success, "flush cache successfully")
+    |> redirect(to: Routes.admin_dashboard_path(conn, :index))
+  end
+end

--- a/lib/godwoken_explorer_web/router.ex
+++ b/lib/godwoken_explorer_web/router.ex
@@ -85,10 +85,11 @@ defmodule GodwokenExplorerWeb.Router do
   scope "/admin", GodwokenExplorerWeb.Admin, as: :admin do
     pipe_through(:browser)
 
-    get("/", UDTController, :index)
+    get("/", DashboardController, :index)
     resources("/udts", UDTController, except: [:delete])
     resources("/smart_contracts", SmartContractController, except: [:delete])
     resources("/jobs", JobController, only: [:index, :show, :delete])
+    delete("/flush_poly_version_cache", DashboardController, :flush_poly_version_cache)
   end
 
   # Other scopes may use custom stacks.

--- a/lib/godwoken_explorer_web/templates/admin/dashboard/index.html.eex
+++ b/lib/godwoken_explorer_web/templates/admin/dashboard/index.html.eex
@@ -1,0 +1,7 @@
+<section id="torch-toolbar">
+  <div class="torch-container">
+    <%= link "Flush Poly Version Cache", to: Routes.admin_dashboard_path(@conn, :flush_poly_version_cache), method: :delete %>
+  </div>
+</section>
+<section id="torch-index-content">
+</section>

--- a/lib/godwoken_explorer_web/views/admin/dashboard_view.ex
+++ b/lib/godwoken_explorer_web/views/admin/dashboard_view.ex
@@ -1,0 +1,3 @@
+defmodule GodwokenExplorerWeb.Admin.DashboardView do
+  use GodwokenExplorerWeb, :view
+end


### PR DESCRIPTION
当前的封装的缓存模块没办法在部署后删掉已经存在的cache，由于更新version 的频率很低，所以在后台增加一个功能手动去删除。