### PR TITLE
HotFix: fix compare function for DateTime type

### DIFF
--- a/lib/godwoken_explorer/graphql/resolovers/account_udt.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/account_udt.ex
@@ -257,7 +257,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.AccountUDT do
 
       result =
         (cbus ++ cus)
-        |> Enum.sort_by(&Map.fetch(&1, :updated_at), :desc)
+        |> Enum.sort_by(&Map.fetch(&1, :updated_at), &account_udts_compare_function/2)
         |> Enum.uniq_by(&Map.fetch(&1, :address_hash))
 
       {:ok, result}
@@ -357,7 +357,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.AccountUDT do
 
   defp process_cus_cbus_balance(cus_cubs) do
     cus_cubs
-    |> Enum.sort_by(&{&1.uniq_id, &1.updated_at}, :desc)
+    |> Enum.sort_by(&{&1.uniq_id, &1.updated_at}, &account_udts_compare_function/2)
     |> Enum.reduce({[], nil}, fn c_cb, {acc_list, base} ->
       case base do
         %{uniq_id: uniq_id} ->
@@ -386,5 +386,17 @@ defmodule GodwokenExplorer.Graphql.Resolvers.AccountUDT do
       end
     end)
     |> List.flatten()
+  end
+
+  def account_udts_compare_function({a1, a2}, {b1, b2}) do
+    if a1 >= b1 do
+      true
+    else
+      case DateTime.compare(a2, b2) do
+        :gt -> true
+        :eq -> true
+        _ -> false
+      end
+    end
   end
 end

--- a/test/graphql/account_udt_test.exs
+++ b/test/graphql/account_udt_test.exs
@@ -29,15 +29,19 @@ defmodule GodwokenExplorer.Graphql.AccountUDTTest do
 
     user = insert!(:user)
 
-    base_t = DateTime.utc_now()
-    inc_base_t = DateTime.add(base_t, 10, :second)
-    fetch_base_t = DateTime.add(base_t, -10, :second)
+    # base_t = DateTime.utc_now()
+    # inc_base_t = DateTime.add(base_t, 100, :day)
+    # fetch_base_t = DateTime.add(base_t, -100, :day)
+
+    base_t = ~U[2022-09-07 10:34:14.021000Z]
+    inc_base_t = ~U[2022-09-16 02:56:57.629000Z]
+    fetch_base_t = ~U[2022-07-25 07:53:57.788000Z]
 
     cub =
       insert!(:current_udt_balance,
         address_hash: user.eth_address,
         token_contract_address_hash: native_udt.contract_address_hash,
-        value: 20000,
+        value: 10000,
         token_type: :erc20,
         updated_at: inc_base_t,
         value_fetched_at: fetch_base_t

--- a/test/graphql/account_udt_test.exs
+++ b/test/graphql/account_udt_test.exs
@@ -29,10 +29,6 @@ defmodule GodwokenExplorer.Graphql.AccountUDTTest do
 
     user = insert!(:user)
 
-    # base_t = DateTime.utc_now()
-    # inc_base_t = DateTime.add(base_t, 100, :day)
-    # fetch_base_t = DateTime.add(base_t, -100, :day)
-
     base_t = ~U[2022-09-07 10:34:14.021000Z]
     inc_base_t = ~U[2022-09-16 02:56:57.629000Z]
     fetch_base_t = ~U[2022-07-25 07:53:57.788000Z]


### PR DESCRIPTION
elixir Enum.sort_by default sorter `asc` and `desc`  which is a convenience for [`&<=/2`](https://hexdocs.pm/elixir/1.13/Kernel.html#%3C=/2) and [`&>=/2`](https://hexdocs.pm/elixir/1.13/Kernel.html#%3E=/2) respectively. 

in erlang world ,all of `term` is comparable

In this pr scenario, we need compare `updated_at` field by sorting return data and distinct it.

but the `DateTime` compare with default sorter not return correct result
it cause some error like this
```
iex(1)> ~U[2022-07-25 07:53:57.788000Z] > ~U[2022-09-07 10:34:14.021000Z]
true

iex(2)> DateTime.utc_now
~U[2022-09-17 04:00:49.814911Z]
iex(3)> ~U[2022-09-17 04:00:49.814911Z] > ~U[2022-09-07 10:34:14.021000Z]
true
```

so we need add a custom sorter to replace the default sorter `asc/desc` by using `DateTime` compare function
```
iex(4)> DateTime.compare(~U[2022-07-25 07:53:57.788000Z], ~U[2022-09-07 10:34:14.021000Z])
:lt
iex(5)> DateTime.compare(~U[2022-09-17 04:00:49.814911Z], ~U[2022-09-07 10:34:14.021000Z])
:gt                      
iex(6)> 
```