### PR TITLE
Fix: add default uniq cursor fields for transction api

### DIFF
--- a/lib/godwoken_explorer/graphql/resolovers/transaction.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/transaction.ex
@@ -33,7 +33,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
           _ ->
             false
         end
-    end)
+      end)
 
     from(t in Transaction, where: ^conditions)
   end
@@ -233,6 +233,11 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
 
     if sorter do
       order_params = cursor_order_sorter(sorter, :order, @sorter_fields)
+      base = Enum.map(order_params, fn {_, e} -> e end)
+      extend = [:hash] -- base
+      extend = extend |> Enum.map(fn e -> {:asc, e} end)
+      order_params = order_params ++ extend
+
       order_by(query, [u], ^order_params)
     else
       order_by(query, [u], @default_sorter)
@@ -243,7 +248,11 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
     sorter = Map.get(input, :sorter)
 
     if sorter do
-      cursor_order_sorter(sorter, :cursor, @sorter_fields)
+      cursor_params = cursor_order_sorter(sorter, :cursor, @sorter_fields)
+      base = Enum.map(cursor_params, fn {e, _} -> e end)
+      extend = [:hash] -- base
+      extend = extend |> Enum.map(fn e -> {e, :asc} end)
+      cursor_params ++ extend
     else
       @default_sorter
     end

--- a/lib/godwoken_explorer/graphql/resolovers/transaction.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/transaction.ex
@@ -10,6 +10,8 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
   alias GodwokenExplorer.{Account, Transaction, Block, Polyjuice, PolyjuiceCreator}
   alias GodwokenExplorer.Chain.Data
 
+  import GodwokenExplorer.Graphql.Utils, only: [default_uniq_cursor_order_fields: 3]
+
   @sorter_fields [:block_number, :index, :hash]
   @default_sorter [:block_number, :index, :hash]
   @account_tx_limit 100_000
@@ -232,11 +234,10 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
     sorter = Map.get(input, :sorter)
 
     if sorter do
-      order_params = cursor_order_sorter(sorter, :order, @sorter_fields)
-      base = Enum.map(order_params, fn {_, e} -> e end)
-      extend = [:hash] -- base
-      extend = extend |> Enum.map(fn e -> {:asc, e} end)
-      order_params = order_params ++ extend
+      order_params =
+        sorter
+        |> cursor_order_sorter(:order, @sorter_fields)
+        |> default_uniq_cursor_order_fields(:order, [:hash])
 
       order_by(query, [u], ^order_params)
     else
@@ -248,11 +249,9 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
     sorter = Map.get(input, :sorter)
 
     if sorter do
-      cursor_params = cursor_order_sorter(sorter, :cursor, @sorter_fields)
-      base = Enum.map(cursor_params, fn {e, _} -> e end)
-      extend = [:hash] -- base
-      extend = extend |> Enum.map(fn e -> {e, :asc} end)
-      cursor_params ++ extend
+      sorter
+      |> cursor_order_sorter(:cursor, @sorter_fields)
+      |> default_uniq_cursor_order_fields(:cursor, [:hash])
     else
       @default_sorter
     end

--- a/lib/godwoken_explorer/graphql/utils.ex
+++ b/lib/godwoken_explorer/graphql/utils.ex
@@ -1,0 +1,24 @@
+defmodule GodwokenExplorer.Graphql.Utils do
+  def default_uniq_cursor_order_fields(cursor_order_params, type, uniq_fields)
+      when type in [:cursor, :order] do
+    base =
+      Enum.map(cursor_order_params, fn {e1, e2} ->
+        if type == :cursor do
+          e1
+        else
+          e2
+        end
+      end)
+
+    extend = uniq_fields -- base
+
+    extend =
+      if type == :cursor do
+        extend |> Enum.map(fn e -> {e, :asc} end)
+      else
+        extend |> Enum.map(fn e -> {:asc, e} end)
+      end
+
+    cursor_order_params ++ extend
+  end
+end


### PR DESCRIPTION
problem:
when use calling the transcation api with sorter `[:block_number]` the paginator may return unexpect results with duplicate value of previous page.

this pr solve:
add default implicit unique sorter feilds for paginator to comfirm the returning cursor‘s uniqueness

example:
if call transaction api with sorter [:block_number],we will change it to [:block_number, :hash] to comfirm the uniqueness