### PR TITLE
feat: filter withdrawal history by state

### DIFF
--- a/lib/godwoken_explorer_web/controllers/api/withdrawal_history_controller.ex
+++ b/lib/godwoken_explorer_web/controllers/api/withdrawal_history_controller.ex
@@ -7,6 +7,7 @@ defmodule GodwokenExplorerWeb.API.WithdrawalHistoryController do
     results =
       WithdrawalHistoryView.find_by_owner_lock_hash(
         String.downcase(params["owner_lock_hash"]),
+        conn.params["state"],
         conn.params["page"] || 1
       )
 
@@ -23,6 +24,7 @@ defmodule GodwokenExplorerWeb.API.WithdrawalHistoryController do
     results =
       WithdrawalHistoryView.find_by_l2_script_hash(
         String.downcase(params["l2_script_hash"]),
+        conn.params["state"],
         conn.params["page"] || 1
       )
 
@@ -42,7 +44,11 @@ defmodule GodwokenExplorerWeb.API.WithdrawalHistoryController do
            %Account{script_hash: script_hash} <-
              Repo.get_by(Account, eth_address: address_hash) do
         results =
-          WithdrawalHistoryView.find_by_l2_script_hash(script_hash, conn.params["page"] || 1)
+          WithdrawalHistoryView.find_by_l2_script_hash(
+            script_hash,
+            conn.params["state"],
+            conn.params["page"] || 1
+          )
 
         JSONAPI.Serializer.serialize(WithdrawalHistoryView, results.entries, conn, %{
           total_page: results.total_pages,

--- a/lib/godwoken_explorer_web/views/withdrawal_history_view.ex
+++ b/lib/godwoken_explorer_web/views/withdrawal_history_view.ex
@@ -1,7 +1,6 @@
 defmodule GodwokenExplorer.WithdrawalHistoryView do
   use JSONAPI.View, type: "withdrawal_history"
   use Retry
-
   use GodwokenExplorer, :schema
 
   def fields do
@@ -47,21 +46,35 @@ defmodule GodwokenExplorer.WithdrawalHistoryView do
     to_string(withdrawal_history.payment_lock_hash)
   end
 
-  def find_by_l2_script_hash(l2_script_hash, page) do
-    query_results = base_query(dynamic([h], h.l2_script_hash == ^l2_script_hash), page)
+  def find_by_l2_script_hash(l2_script_hash, state, page) do
+    base_condition = dynamic([h], h.l2_script_hash == ^l2_script_hash)
+
+    condition =
+      if state in ["pending", "available", "succeed"],
+        do: dynamic([h], h.state == ^state and ^base_condition),
+        else: base_condition
+
+    query_results = base_query(condition, page)
 
     if updated_state?(query_results) do
-      base_query(dynamic([h], h.l2_script_hash == ^l2_script_hash), page)
+      base_query(condition, page)
     else
       query_results
     end
   end
 
-  def find_by_owner_lock_hash(owner_lock_hash, page) do
-    query_results = base_query(dynamic([h], h.owner_lock_hash == ^owner_lock_hash), page)
+  def find_by_owner_lock_hash(owner_lock_hash, state, page) do
+    base_condition = dynamic([h], h.owner_lock_hash == ^owner_lock_hash)
+
+    condition =
+      if state in ["pending", "available", "succeed"],
+        do: dynamic([h], h.state == ^state and ^base_condition),
+        else: base_condition
+
+    query_results = base_query(condition, page)
 
     if updated_state?(query_results) do
-      base_query(dynamic([h], h.owner_lock_hash == ^owner_lock_hash), page)
+      base_query(condition, page)
     else
       query_results
     end

--- a/test/factories/deposit_history_factory.ex
+++ b/test/factories/deposit_history_factory.ex
@@ -8,11 +8,11 @@ defmodule GodwokenExplorer.DepositHistoryFactory do
         %DepositHistory{
           amount: D.new(40_000_000_000),
           capacity: D.new(40_000_000_000),
-          ckb_lock_hash: "0xe6c7befcbf4697f1a7f8f04ffb8de71f5304826af7bfce3e4d396483e935820a",
-          layer1_block_number: 5_744_914,
+          ckb_lock_hash: transaction_hash(),
+          layer1_block_number: block_number(),
           layer1_output_index: 0,
-          layer1_tx_hash: "0x41876f5c3ea0d96219c42ea5b4e6cedba61c59fa39bf163765a302f6e43c3847",
-          script_hash: "0xfa2ae9de22bbca35fc44f20efe7a3d2789556d4c50a7c2b4e460269f13b77c58",
+          layer1_tx_hash: transaction_hash(),
+          script_hash: transaction_hash(),
           timestamp: ~U[2021-12-02 22:39:39.585000Z],
           udt_id: 1
         }

--- a/test/factories/withdrawal_history_factory.ex
+++ b/test/factories/withdrawal_history_factory.ex
@@ -6,19 +6,19 @@ defmodule GodwokenExplorer.WithdrawalHistoryFactory do
     quote do
       def withdrawal_history_factory do
         %WithdrawalHistory{
-          l2_script_hash: "0xfa2ae9de22bbca35fc44f20efe7a3d2789556d4c50a7c2b4e460269f13b77c58",
-          amount: D.new(10_000_000_000),
-          block_hash: "0x07aafde68ea70169bb54cf76b44496d8f5deba5ac89cb1ddc20d10646ddfc09f",
-          block_number: 68738,
-          owner_lock_hash: "0x66db0f8f6b0ac8b4e92fdfcef8d04a3251a118ccae0ff436957e2c646f083ebd",
+          l2_script_hash: transaction_hash(),
+          amount: Enum.random(100_000..200_000) |> D.new(),
+          block_hash: transaction_hash(),
+          block_number: block_number(),
+          owner_lock_hash: transaction_hash(),
           udt_script_hash: "0x0000000000000000000000000000000000000000000000000000000000000000",
           udt_id: 1,
-          layer1_block_number: 5_744_914,
+          layer1_block_number: block_number(),
           layer1_output_index: 0,
-          layer1_tx_hash: "0x41876f5c3ea0d96219c42ea5b4e6cedba61c59fa39bf163765a302f6e43c3847",
+          layer1_tx_hash: transaction_hash(),
           timestamp: ~U[2021-12-03 22:39:39.585000Z],
           state: :pending,
-          capacity: D.new(10_000_000_000)
+          capacity: Enum.random(10_000_000_000..20_000_000_000) |> D.new()
         }
       end
     end

--- a/test/godwoken_explorer_web/controllers/api/withdrawal_history_controller_test.exs
+++ b/test/godwoken_explorer_web/controllers/api/withdrawal_history_controller_test.exs
@@ -1,0 +1,158 @@
+defmodule GodwokenExplorerWeb.API.WithdrawalHistoryControllerTest do
+  use GodwokenExplorerWeb.ConnCase
+
+  import GodwokenExplorer.Factory
+  import Mock
+
+  alias Decimal, as: D
+
+  setup do
+    udt = insert(:ckb_udt)
+    insert(:ckb_account)
+    ckb_native = insert(:ckb_native_udt)
+    ckb_contract = insert(:ckb_contract_account, eth_address: ckb_native.contract_address_hash)
+    user = insert(:user)
+
+    withdrawal = insert(:withdrawal_history, l2_script_hash: user.script_hash)
+
+    available_withdrawal =
+      insert(:withdrawal_history, l2_script_hash: user.script_hash, state: :available)
+
+    %{
+      withdrawal: withdrawal,
+      user: user,
+      udt: udt,
+      ckb_contract: ckb_contract,
+      available_withdrawal: available_withdrawal
+    }
+  end
+
+  describe "index" do
+    test "lists eth address withdrawal", %{
+      conn: conn,
+      withdrawal: withdrawal,
+      available_withdrawal: available_withdrawal,
+      user: user,
+      udt: udt,
+      ckb_contract: ckb_contract
+    } do
+      with_mock GodwokenRPC, fetch_live_cell: fn _, _ -> {:ok, true} end do
+        conn =
+          get(
+            conn,
+            Routes.withdrawal_history_path(conn, :index, eth_address: to_string(user.eth_address))
+          )
+
+        assert json_response(conn, 200) ==
+                 %{
+                   "data" => [
+                     %{
+                       "attributes" => %{
+                         "l2_script_hash" => to_string(available_withdrawal.l2_script_hash),
+                         "block_hash" => to_string(available_withdrawal.block_hash),
+                         "block_number" => available_withdrawal.block_number,
+                         "udt_script_hash" => available_withdrawal.udt_script_hash |> to_string(),
+                         "owner_lock_hash" => available_withdrawal.owner_lock_hash |> to_string(),
+                         "state" => "#{available_withdrawal.state}",
+                         "layer1_block_number" => available_withdrawal.layer1_block_number,
+                         "layer1_output_index" => available_withdrawal.layer1_output_index,
+                         "layer1_tx_hash" => to_string(available_withdrawal.layer1_tx_hash),
+                         "timestamp" => available_withdrawal.timestamp |> DateTime.to_iso8601(),
+                         "amount" => available_withdrawal.amount |> D.to_string(),
+                         "capacity" => available_withdrawal.capacity |> to_string(),
+                         "udt_id" => udt.id,
+                         "udt" => %{
+                           "eth_address" => ckb_contract.eth_address |> to_string(),
+                           "name" => udt.name,
+                           "symbol" => udt.symbol
+                         }
+                       },
+                       "id" => "#{available_withdrawal.id}",
+                       "relationships" => %{},
+                       "type" => "withdrawal_history"
+                     },
+                     %{
+                       "attributes" => %{
+                         "l2_script_hash" => to_string(withdrawal.l2_script_hash),
+                         "block_hash" => to_string(withdrawal.block_hash),
+                         "block_number" => withdrawal.block_number,
+                         "udt_script_hash" => withdrawal.udt_script_hash |> to_string(),
+                         "owner_lock_hash" => withdrawal.owner_lock_hash |> to_string(),
+                         "state" => "#{withdrawal.state}",
+                         "layer1_block_number" => withdrawal.layer1_block_number,
+                         "layer1_output_index" => withdrawal.layer1_output_index,
+                         "layer1_tx_hash" => to_string(withdrawal.layer1_tx_hash),
+                         "timestamp" => withdrawal.timestamp |> DateTime.to_iso8601(),
+                         "amount" => withdrawal.amount |> D.to_string(),
+                         "capacity" => withdrawal.capacity |> to_string(),
+                         "udt_id" => udt.id,
+                         "udt" => %{
+                           "eth_address" => ckb_contract.eth_address |> to_string(),
+                           "name" => udt.name,
+                           "symbol" => udt.symbol
+                         }
+                       },
+                       "id" => "#{withdrawal.id}",
+                       "relationships" => %{},
+                       "type" => "withdrawal_history"
+                     }
+                   ],
+                   "included" => [],
+                   "meta" => %{"current_page" => 1, "total_page" => 1}
+                 }
+      end
+    end
+
+    test "lists eth address unlocked withdrawal", %{
+      conn: conn,
+      available_withdrawal: available_withdrawal,
+      user: user,
+      udt: udt,
+      ckb_contract: ckb_contract
+    } do
+      with_mock GodwokenRPC, fetch_live_cell: fn _, _ -> {:ok, true} end do
+        conn =
+          get(
+            conn,
+            Routes.withdrawal_history_path(conn, :index,
+              eth_address: to_string(user.eth_address),
+              state: "available"
+            )
+          )
+
+        assert json_response(conn, 200) ==
+                 %{
+                   "data" => [
+                     %{
+                       "attributes" => %{
+                         "l2_script_hash" => to_string(available_withdrawal.l2_script_hash),
+                         "block_hash" => to_string(available_withdrawal.block_hash),
+                         "block_number" => available_withdrawal.block_number,
+                         "udt_script_hash" => available_withdrawal.udt_script_hash |> to_string(),
+                         "owner_lock_hash" => available_withdrawal.owner_lock_hash |> to_string(),
+                         "state" => "#{available_withdrawal.state}",
+                         "layer1_block_number" => available_withdrawal.layer1_block_number,
+                         "layer1_output_index" => available_withdrawal.layer1_output_index,
+                         "layer1_tx_hash" => to_string(available_withdrawal.layer1_tx_hash),
+                         "timestamp" => available_withdrawal.timestamp |> DateTime.to_iso8601(),
+                         "amount" => available_withdrawal.amount |> D.to_string(),
+                         "capacity" => available_withdrawal.capacity |> to_string(),
+                         "udt_id" => udt.id,
+                         "udt" => %{
+                           "eth_address" => ckb_contract.eth_address |> to_string(),
+                           "name" => udt.name,
+                           "symbol" => udt.symbol
+                         }
+                       },
+                       "id" => "#{available_withdrawal.id}",
+                       "relationships" => %{},
+                       "type" => "withdrawal_history"
+                     }
+                   ],
+                   "included" => [],
+                   "meta" => %{"current_page" => 1, "total_page" => 1}
+                 }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What problem does this PR solve?
User can filter withdrawal history by state params. State can pass [pending, available, succeed]