### PR TITLE
feat: auto create account from polyjuice creator transaction

### DIFF
--- a/lib/godwoken_explorer/account.ex
+++ b/lib/godwoken_explorer/account.ex
@@ -576,7 +576,12 @@ defmodule GodwokenExplorer.Account do
   end
 
   def batch_import_accounts_with_script_hashes(script_hashes) do
-    params = script_hashes |> Enum.map(&%{script_hash: &1, script: nil})
+    exist_script_hashes =
+      from(a in Account, where: a.script_hash in ^script_hashes, select: a.script_hash)
+      |> Repo.all()
+
+    not_exist_script_hashes = script_hashes -- exist_script_hashes
+    params = not_exist_script_hashes |> Enum.map(&%{script_hash: &1, script: nil})
 
     {:ok, %GodwokenRPC.Account.FetchedAccountIDs{errors: [], params_list: l2_script_hash_and_ids}} =
       GodwokenRPC.fetch_account_ids(params)

--- a/lib/godwoken_indexer/block/sync_l1_block_worker.ex
+++ b/lib/godwoken_indexer/block/sync_l1_block_worker.ex
@@ -338,13 +338,7 @@ defmodule GodwokenIndexer.Block.SyncL1BlockWorker do
 
       script_hashes = Enum.map(parsed_deposit_histories, &Map.fetch!(&1, :script_hash))
       udt_ids = Enum.map(parsed_deposit_histories, &Map.fetch!(&1, :udt_id))
-
-      exist_script_hashes =
-        from(a in Account, where: a.script_hash in ^script_hashes, select: a.script_hash)
-        |> Repo.all()
-
-      not_exist_script_hashes = script_hashes -- exist_script_hashes
-      Account.batch_import_accounts_with_script_hashes(not_exist_script_hashes)
+      Account.batch_import_accounts_with_script_hashes(script_hashes)
 
       script_hash_with_account_infos =
         from(a in Account,

--- a/test/godwoken_explorer/account_test.exs
+++ b/test/godwoken_explorer/account_test.exs
@@ -1,0 +1,63 @@
+defmodule GodwokenExplorer.AccountTest do
+  use GodwokenExplorer.DataCase
+
+  import Mock
+
+  alias GodwokenExplorer.{Account, Repo}
+
+  test "batch_import_accounts_with_script_hashes" do
+    with_mocks([
+      {GodwokenRPC, [],
+       [
+         fetch_account_ids: fn _ ->
+           {:ok,
+            %GodwokenRPC.Account.FetchedAccountIDs{
+              errors: [],
+              params_list: [
+                %{
+                  script_hash:
+                    "0x74db559cbb4928e1c2dfb6ab30623bb338a53904f47458c02a07be01c84b1af9",
+                  script: nil,
+                  id: 48250
+                }
+              ]
+            }}
+         end
+       ]},
+      {GodwokenRPC, [],
+       [
+         fetch_scripts: fn _ ->
+           {:ok,
+            %{
+              errors: [],
+              params_list: [
+                %{
+                  script_hash:
+                    "0x74db559cbb4928e1c2dfb6ab30623bb338a53904f47458c02a07be01c84b1af9",
+                  script: %{
+                    "args" =>
+                      "0x702359ea7f073558921eb50d8c1c77e92f760c8f8656bde4995f26b8963e2dd80400000017f01ec05a4a6a43857e3bb8d8ddd68e8d1d185f",
+                    "code_hash" =>
+                      "0x1629b04b49ded9e5747481f985b11cba6cdd4ffc167971a585e96729455ca736",
+                    "hash_type" => "type"
+                  },
+                  id: 48250
+                }
+              ]
+            }}
+         end
+       ]}
+    ]) do
+      Account.batch_import_accounts_with_script_hashes([
+        "0x74db559cbb4928e1c2dfb6ab30623bb338a53904f47458c02a07be01c84b1af9"
+      ])
+
+      account = Account |> Repo.one()
+      assert Account |> Repo.aggregate(:count) == 1
+      assert account.id == 48250
+
+      assert account.script_hash |> to_string() ==
+               "0x74db559cbb4928e1c2dfb6ab30623bb338a53904f47458c02a07be01c84b1af9"
+    end
+  end
+end


### PR DESCRIPTION
## What problem does this PR solve?
We can get account code_hash hash_type and args  from polyjuice creator transaction's info.So we can create account with these info. 

## Check List
#### Test
- unit test
#### Task 
 - none