### PR TITLE
HotFix: fix user 721 assert api subfield udt return object

### DIFF
--- a/docs/schema.graphql
+++ b/docs/schema.graphql
@@ -492,15 +492,6 @@ type Erc7211155CommonUdt {
   symbol: String
 }
 
-type Erc721Erc1155CommonUserToken {
-  address_hash: HashAddress
-  counts: Decimal
-  token_contract_address_hash: HashAddress
-  token_id: Decimal
-  token_type: EthType
-  value: Decimal
-}
-
 type Erc721Erc1155HolderItem {
   account: Account
   address_hash: HashAddress
@@ -607,7 +598,7 @@ type Erc721UserToken {
   token_contract_address_hash: HashAddress
   token_id: Decimal
   token_type: EthType
-  udt: Erc721Erc1155CommonUserToken
+  udt: Erc7211155CommonUdt
   value: Decimal
 }
 

--- a/lib/godwoken_explorer/graphql/types/udt.ex
+++ b/lib/godwoken_explorer/graphql/types/udt.ex
@@ -1258,7 +1258,7 @@ defmodule GodwokenExplorer.Graphql.Types.UDT do
   object :erc721_user_token do
     import_fields(:erc721_erc1155_common_user_token)
 
-    field :udt, :erc721_erc1155_common_user_token do
+    field :udt, :erc721_1155_common_udt do
       resolve(&Resolvers.UDT.erc721_erc1155_udt/3)
     end
   end

--- a/test/graphql/udt_test.exs
+++ b/test/graphql/udt_test.exs
@@ -1022,16 +1022,19 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
 
   test "graphql: user_erc721_assets", %{
     conn: conn,
-    user: user
-    # erc721_native_udt: erc721_native_udt
+    user: user,
+    erc721_native_udt: erc721_native_udt
     # erc1155_native_udt: erc1155_native_udt
   } do
     user_address = user.eth_address |> to_string()
+    erc721_udt_id = erc721_native_udt.id
+    erc721_udt_name = erc721_native_udt.name
+    erc721_udt_contract_address_hash = erc721_native_udt.contract_address_hash |> to_string()
 
     query = """
     query {
       user_erc721_assets(
-        input: { user_address: "#{user_address}"}
+        input: {limit: 1, user_address: "#{user_address}"}
       ) {
         entries {
           address_hash
@@ -1039,6 +1042,10 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
           token_id
           token_type
           counts
+          udt {
+            id
+            name
+          }
         }
         metadata {
           total_count
@@ -1058,7 +1065,17 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
     assert match?(
              %{
                "data" => %{
-                 "user_erc721_assets" => %{"metadata" => %{"total_count" => 2}}
+                 "user_erc721_assets" => %{
+                   "entries" => [
+                     %{
+                       "address_hash" => ^user_address,
+                       "token_contract_address_hash" => ^erc721_udt_contract_address_hash,
+                       "token_type" => "ERC721",
+                       "udt" => %{"id" => ^erc721_udt_id, "name" => ^erc721_udt_name}
+                     }
+                   ],
+                   "metadata" => %{"total_count" => 2}
+                 }
                }
              },
              json_response(conn, 200)
@@ -1067,11 +1084,14 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
 
   test "graphql: user_erc1155_assets", %{
     conn: conn,
-    user: user
+    user: user,
     # erc721_native_udt: erc721_native_udt
-    # erc1155_native_udt: erc1155_native_udt
+    erc1155_native_udt: erc1155_native_udt
   } do
     user_address = user.eth_address |> to_string()
+    erc1155_udt_id = erc1155_native_udt.id
+    erc1155_udt_name = erc1155_native_udt.name
+    erc1155_udt_contract_address_hash = erc1155_native_udt.contract_address_hash |> to_string()
 
     query = """
     query {
@@ -1084,6 +1104,10 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
           token_id
           token_type
           counts
+          udt {
+            id
+            name
+          }
         }
         metadata {
           total_count
@@ -1103,7 +1127,18 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
     assert match?(
              %{
                "data" => %{
-                 "user_erc1155_assets" => %{"metadata" => %{"total_count" => 2}}
+                 "user_erc1155_assets" => %{
+                   "entries" => [
+                     %{
+                       "address_hash" => ^user_address,
+                       "token_contract_address_hash" => ^erc1155_udt_contract_address_hash,
+                       "token_type" => "ERC1155",
+                       "udt" => %{"id" => ^erc1155_udt_id, "name" => ^erc1155_udt_name}
+                     },
+                     _
+                   ],
+                   "metadata" => %{"total_count" => 2}
+                 }
                }
              },
              json_response(conn, 200)


### PR DESCRIPTION
## What problem does this PR solve?
https://github.com/Magickbase/godwoken_explorer/issues/1034
Token name is missing when calling the user721_asserts api with `udt` subfield object 

## Cause
use incorrect object for user721_asserts `udt` subfield 
must use `erc721_1155_common_udt` object

## Check List
stg env example
```graphql
query {
  user_erc721_assets(
    input: {
      user_address: "0x0000000000ce6d8c1fba76f26d6cc5db71432710"
      limit: 1
    }
  ) {
    entries {
      token_id
      address_hash
      token_contract_address_hash
      value
      udt {
        id
        name
      }
    }
    metadata {
      total_count
      after
      before
    }
  }
}

```

result
```
{
  "data": {
    "user_erc721_assets": {
      "entries": [
        {
          "address_hash": "0x0000000000ce6d8c1fba76f26d6cc5db71432710",
          "token_contract_address_hash": "0x76ef87aaaa9213b1e7f96460e23bd9d0b7dbcc64",
          "token_id": "812",
          "udt": {
            "id": 70030,
            "name": "NervosPunkz"
          },
          "value": "1"
        }
      ],
      "metadata": {
        "after": "g3QAAAACZAAMYmxvY2tfbnVtYmVyYgAFZHVkABB2YWx1ZV9mZXRjaGVkX2F0dAAAAA1kAApfX3N0cnVjdF9fZAAPRWxpeGlyLkRhdGVUaW1lZAAIY2FsZW5kYXJkABNFbGl4aXIuQ2FsZW5kYXIuSVNPZAADZGF5YQhkAARob3VyYQZkAAttaWNyb3NlY29uZGgCYgACCJ5hBmQABm1pbnV0ZWENZAAFbW9udGhhCWQABnNlY29uZGE5ZAAKc3RkX29mZnNldGEAZAAJdGltZV96b25lbQAAAAdFdGMvVVRDZAAKdXRjX29mZnNldGEAZAAEeWVhcmIAAAfmZAAJem9uZV9hYmJybQAAAANVVEM=",
        "before": null,
        "total_count": 5
      }
    }
  }
}
```

#### Test
- unit test
#### Task
 - none
