### PR TITLE
Issue 1032 2

### DIFF
--- a/lib/godwoken_rpc/transaction.ex
+++ b/lib/godwoken_rpc/transaction.ex
@@ -70,9 +70,6 @@ defmodule GodwokenRPC.Transaction do
         [is_create, gas_limit, gas_price, value, input_size, input, native_transfer_address_hash] =
           parse_polyjuice_args(args)
 
-        native_transfer_address_hash =
-          if native_transfer_address_hash == "0x", do: nil, else: native_transfer_address_hash
-
         %{
           type: :polyjuice,
           hash: hash,

--- a/lib/godwoken_rpc/util.ex
+++ b/lib/godwoken_rpc/util.ex
@@ -192,7 +192,9 @@ defmodule GodwokenRPC.Util do
     input = hex_string |> String.slice(104, input_size * 2)
 
     native_transfer_address =
-      if input_size == 0, do: "0x" <> (hex_string |> String.slice(104..-1)), else: nil
+      if input_size == 0 and String.length(hex_string) == 144,
+        do: "0x" <> (hex_string |> String.slice(104..-1)),
+        else: nil
 
     [is_create, gas_limit, gas_price, value, input_size, "0x" <> input, native_transfer_address]
   end

--- a/test/godwoken_rpc/util_test.exs
+++ b/test/godwoken_rpc/util_test.exs
@@ -1,0 +1,33 @@
+defmodule GodwokenRPC.UtilTest do
+  use GodwokenExplorer.DataCase
+
+  alias GodwokenRPC.Util
+
+  describe "parse_polyjuice_args" do
+    test "when is native transfer" do
+      result =
+        Util.parse_polyjuice_args(
+          "ffffff504f4c590068bf00000000000000a007c2da51000000000000000000000000e867ce97461d310000000000000000000000715ab282b873b79a7be8b0e8c13c4e8966a52040"
+        )
+
+      assert result == [
+               false,
+               49000,
+               90_000_000_000_000,
+               906_000_000_000_000_000_000,
+               0,
+               "0x",
+               "0x715ab282b873b79a7be8b0e8c13c4e8966a52040"
+             ]
+    end
+
+    test "when is other polyjuice args" do
+      result =
+        Util.parse_polyjuice_args(
+          "ffffff504f4c590000c076000000000001e40b540200000000000000000000000002000000000000000000000000000000000000"
+        )
+
+      assert result == [false, 7_782_400, 10_000_000_001, 512, 0, "0x", nil]
+    end
+  end
+end


### PR DESCRIPTION
## What problem does this PR solve?
When polyjuice args input_size is 0, we need to check that args length is 144.Only in this cause, it is a native transfer transaction.
## Check List
#### Test
- [x] unit test
#### Task
 - none
