### PR TITLE
feat: retry for rpc eth_block_by_hash

### DIFF
--- a/lib/godwoken_rpc/block.ex
+++ b/lib/godwoken_rpc/block.ex
@@ -51,8 +51,14 @@ defmodule GodwokenRPC.Block do
        "size" => size,
        "logsBloom" => logs_bloom
      }} =
-      retry with: constant_backoff(5000) |> Stream.take(3) do
-        GodwokenRPC.fetch_eth_block_by_hash(hash)
+      retry with: constant_backoff(5000) |> Stream.take(3), rescue_only: [MatchError] do
+        {:ok,
+         %{
+           "gasLimit" => _gas_limit,
+           "gasUsed" => _gas_used,
+           "size" => _size,
+           "logsBloom" => _logs_bloom
+         }} = GodwokenRPC.fetch_eth_block_by_hash(hash)
       after
         result -> result
       else


### PR DESCRIPTION
## What problem does this PR solve?
From our error logs, we found that eth_block_by_hash rpc have big probability to failed.Although our sync worker will retry and can keep data correct.But it will generate a lot of error log.
So in first step, we add retry for this rpc fetch every 5 seconds and keep watching for these logs 
## Check List
#### Test
- none
#### Task
 - none
