### PR TITLE
ci: remove codeql for ruby

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'ruby' ]
+        language: [ 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 


### PR DESCRIPTION
## What problem does this PR solve?

This commit removes codeql for ruby because all ruby codes have been removed by https://github.com/Magickbase/godwoken_explorer/pull/1058 which introduced a blame that no source code is found

Ref: https://github.com/Magickbase/godwoken_explorer/actions/runs/3213239075/jobs/5252762510

## Check List
#### Test
 - none
#### Task
 - none
