### PR TITLE
chore: increase block count to calculate average block time

### DIFF
--- a/lib/godwoken_explorer/counters/average_block_time.ex
+++ b/lib/godwoken_explorer/counters/average_block_time.ex
@@ -10,7 +10,7 @@ defmodule GodwokenExplorer.Counters.AverageBlockTime do
   alias GodwokenExplorer.{Block, Repo}
   alias Timex.Duration
 
-  @latest_block_count 12
+  @latest_block_count 24
 
   @doc """
   Starts a process to periodically update the counter of the token holders.


### PR DESCRIPTION
## What problem does this PR solve?
calculate average block time with 12 block's timestamp is not precise, so increase to 24
## Check List
#### Test
- none
#### Task
 - none
