### PR TITLE
HotFix: fix udt api raise error when input not exist address

### DIFF
--- a/lib/godwoken_explorer/graphql/resolovers/udt.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/udt.ex
@@ -131,7 +131,13 @@ defmodule GodwokenExplorer.Graphql.Resolvers.UDT do
     mapping_udt = UDT.find_mapping_udt(udt)
     udt = merge_bridge_info_to_udt(udt, mapping_udt)
     hc = UDT.count_holder(udt)
-    udt = udt |> Map.put(:holders_count, hc)
+
+    udt =
+      if udt do
+        udt |> Map.put(:holders_count, hc)
+      else
+        nil
+      end
 
     {:ok, udt}
   end


### PR DESCRIPTION
## What problem does this PR solve?
link issue: #1072
## Check List
1. fix raise internal erroc when call `udt` api by using nonexist address  

## testnet-stg example
```graphql
query {
  udt(
    input: { contract_address: "0xeeb92d6b3999abdc8cc0226069d88c07f241fd4c" }
  ) {
    contract_address_hash
    symbol
    name
  }
}

{
  "data": {
    "udt": {
      "contract_address_hash": "0xeeb92d6b3999abdc8cc0226069d88c07f241fd4c",
      "name": null,
      "symbol": null
    }
  }
}

query {
  udt(
    input: { contract_address: "0xeeb92d6b3999abdc8cc0226069d88c07f241fd4e" }
  ) {
    contract_address_hash
    symbol
    name
  }
}

{
  "data": {
    "udt": null
  }
}
```
#### Test
- unit test
#### Task
 - none
