### PR TITLE
fix: datetime sort_by must use  to compare

### DIFF
--- a/lib/godwoken_explorer/account/current_udt_balance.ex
+++ b/lib/godwoken_explorer/account/current_udt_balance.ex
@@ -85,8 +85,8 @@ defmodule GodwokenExplorer.Account.CurrentUDTBalance do
       |> Repo.all()
 
     (bridged_udt_balances ++ udt_balances)
-    |> Enum.sort_by(&Map.fetch(&1, :updated_at), :desc)
-    |> Enum.uniq_by(&Map.fetch(&1, :id))
+    |> Enum.sort_by(&Map.fetch!(&1, :updated_at), &(DateTime.compare(&1, &2) != :lt))
+    |> Enum.uniq_by(&Map.fetch!(&1, :id))
     |> Enum.map(fn record ->
       record
       |> Map.merge(%{balance: balance_to_view(record[:balance], record[:udt_decimal] || 0)})
@@ -127,8 +127,8 @@ defmodule GodwokenExplorer.Account.CurrentUDTBalance do
         |> Repo.all()
 
       (bridged_results ++ results)
-      |> Enum.sort_by(&Map.fetch(&1, :updated_at), :desc)
-      |> Enum.uniq_by(&Map.fetch(&1, :address_hash))
+      |> Enum.sort_by(&Map.fetch!(&1, :updated_at), &(DateTime.compare(&1, &2) != :lt))
+      |> Enum.uniq_by(&Map.fetch!(&1, :address_hash))
     else
       bridged_results
     end

--- a/lib/godwoken_explorer/counters/average_block_time.ex
+++ b/lib/godwoken_explorer/counters/average_block_time.ex
@@ -70,7 +70,7 @@ defmodule GodwokenExplorer.Counters.AverageBlockTime do
 
     timestamps =
       timestamps_row
-      |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &>=/2)
+      |> Enum.sort_by(fn {_, timestamp} -> timestamp end, &(DateTime.compare(&1, &2) != :lt))
       |> Enum.map(fn {number, timestamp} ->
         {number, DateTime.to_unix(timestamp, :millisecond)}
       end)


### PR DESCRIPTION
## What problem does this PR solve?
Datetime type data can't directly use default sort_by, it must use `DateTime.compare/2` function to compare
## Check List
#### Test
- none
#### Task
 - none
