### PR TITLE
feat: create udt account before create udt

### DIFF
--- a/lib/godwoken_indexer/block/sync_worker.ex
+++ b/lib/godwoken_indexer/block/sync_worker.ex
@@ -454,6 +454,11 @@ defmodule GodwokenIndexer.Block.SyncWorker do
       not_exist_contract_address = contract_address_hashes -- exist_contract_addresses
 
       if length(not_exist_contract_address) > 0 do
+        not_exist_contract_address
+        |> Enum.each(fn address ->
+          Account.find_or_create_contract_by_eth_address(address)
+        end)
+
         eth_address_to_ids =
           from(a in Account,
             where: a.eth_address in ^not_exist_contract_address,


### PR DESCRIPTION
## What problem does this PR solve?
When we create udt,we need to find it's relationship of account.But account may not exist at this time, so we need to create account first.
## Check List
#### Test
- none
#### Task
 - none
