### PR TITLE
Issue 1079 2

### DIFF
--- a/lib/godwoken_explorer/token/metadata_retriever.ex
+++ b/lib/godwoken_explorer/token/metadata_retriever.ex
@@ -180,7 +180,7 @@ defmodule GodwokenExplorer.Token.MetadataRetriever do
         |> Repo.get_by(contract_address_hash: contract_address_hash)
         |> Repo.preload([:account])
 
-      set_skip_metadata(token_to_update)
+      if token_to_update != nil, do: set_skip_metadata(token_to_update)
     end
 
     res

--- a/lib/godwoken_explorer/udt.ex
+++ b/lib/godwoken_explorer/udt.ex
@@ -323,6 +323,7 @@ defmodule GodwokenExplorer.UDT do
 
     case GodwokenRPC.eth_call(%{
            to: contract_address,
+           gas: "0x7530",
            data: method_sig
          }) do
       {:ok, hex_name} ->
@@ -353,6 +354,48 @@ defmodule GodwokenExplorer.UDT do
 
       _ ->
         ""
+    end
+  end
+
+  def is_erc721?(contract_address) do
+    method_sig = "0x01ffc9a7"
+    erc721_interface_id = "780e9d63"
+
+    case GodwokenRPC.eth_call(%{
+           to: contract_address,
+           # gas: 30000
+           gas: "0x7530",
+           # 36 bytes
+           data:
+             method_sig <>
+               erc721_interface_id <> "00000000000000000000000000000000000000000000000000000000"
+         }) do
+      {:ok, result} ->
+        result == "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+      _ ->
+        false
+    end
+  end
+
+  def is_erc1155?(contract_address) do
+    method_sig = "0x01ffc9a7"
+    erc1155_interface_id = "4e2312e0"
+
+    case GodwokenRPC.eth_call(%{
+           to: contract_address,
+           # gas: 30000
+           gas: "0x7530",
+           # 36 bytes
+           data:
+             method_sig <>
+               erc1155_interface_id <> "00000000000000000000000000000000000000000000000000000000"
+         }) do
+      {:ok, result} ->
+        result == "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+      _ ->
+        false
     end
   end
 

--- a/lib/godwoken_indexer/worker/check_contract_udt.ex
+++ b/lib/godwoken_indexer/worker/check_contract_udt.ex
@@ -1,0 +1,98 @@
+defmodule GodwokenIndexer.Worker.CheckContractUDT do
+  use Oban.Worker, queue: :default
+
+  import Ecto.Query, only: [from: 2]
+
+  alias GodwokenExplorer.{Account, Repo, SmartContract, UDT}
+  alias GodwokenExplorer.Token.MetadataRetriever
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"address" => address}}) do
+    check_is_erc721(address)
+    check_is_erc1155(address)
+    check_is_erc20(address)
+
+    :ok
+  end
+
+  defp check_is_erc1155(address) do
+    with true <- UDT.is_erc1155?(address),
+         %Account{id: id, contract_code: contract_code} <-
+           Repo.get_by(Account, eth_address: address),
+         nil <- Repo.get(UDT, id) do
+      %UDT{}
+      |> UDT.changeset(%{
+        id: id,
+        type: :native,
+        eth_type: :erc1155,
+        contract_address_hash: address
+      })
+      |> Repo.insert()
+
+      if contract_code != nil, do: import_exist_smart_contract(contract_code, id)
+    end
+  end
+
+  defp check_is_erc20(address) do
+    with %{name: _name, symbol: _symbol, supply: _supply, decimal: _decimal} <-
+           MetadataRetriever.get_functions_of(address),
+         %Account{id: id, contract_code: contract_code} <-
+           Repo.get_by(Account, eth_address: address),
+         nil <- Repo.get(UDT, id) do
+      %UDT{}
+      |> UDT.changeset(%{
+        id: id,
+        type: :native,
+        eth_type: :erc20,
+        contract_address_hash: address
+      })
+      |> Repo.insert()
+
+      if contract_code != nil, do: import_exist_smart_contract(contract_code, id)
+    end
+  end
+
+  defp check_is_erc721(address) do
+    with true <- UDT.is_erc721?(address),
+         %Account{id: id, contract_code: contract_code} <-
+           Repo.get_by(Account, eth_address: address),
+         nil <- Repo.get(UDT, id) do
+      %UDT{}
+      |> UDT.changeset(%{
+        id: id,
+        type: :native,
+        eth_type: :erc721,
+        contract_address_hash: address
+      })
+      |> Repo.insert()
+
+      if contract_code != nil, do: import_exist_smart_contract(contract_code, id)
+    end
+  end
+
+  defp import_exist_smart_contract(contract_code, id) do
+    sc =
+      from(a in Account,
+        join: sc in SmartContract,
+        on: sc.account_id == a.id,
+        where: a.contract_code == ^contract_code and a.id != ^id and not is_nil(sc.abi),
+        select: sc,
+        limit: 1
+      )
+      |> Repo.one()
+
+    if sc != nil do
+      Repo.insert(
+        %SmartContract{
+          name: sc.name,
+          account_id: id,
+          abi: sc.abi,
+          contract_source_code: sc.contract_source_code,
+          compiler_version: sc.compiler_version
+        },
+        on_conflict: {:replace, [:name, :abi, :contract_source_code, :compiler_version]},
+        conflict_target: :account_id
+      )
+    end
+  end
+end

--- a/test/factories/account_factory.ex
+++ b/test/factories/account_factory.ex
@@ -46,7 +46,8 @@ defmodule GodwokenExplorer.AccountFactory do
           script_hash: block_hash(),
           type: :polyjuice_contract,
           eth_address: address_hash(),
-          token_transfer_count: 0
+          token_transfer_count: 0,
+          contract_code: data(:contract_code)
         }
       end
 

--- a/test/godwoken_indexer/worker/check_contract_udt_test.exs
+++ b/test/godwoken_indexer/worker/check_contract_udt_test.exs
@@ -1,0 +1,51 @@
+defmodule GodwokenIndexer.Worker.CheckContractUDTTest do
+  use GodwokenExplorer.DataCase
+
+  import GodwokenExplorer.Factory
+  import Mock
+
+  alias GodwokenIndexer.Worker.CheckContractUDT
+  alias GodwokenExplorer.{Account, Repo, SmartContract, UDT}
+  alias GodwokenExplorer.Token.MetadataRetriever
+
+  setup do
+    sample_erc20 = insert(:polyjuice_contract_account, id: Account.erc20_sample_id())
+    insert(:native_udt, id: sample_erc20.id)
+    sample_smart_contract = insert(:smart_contract, account: sample_erc20)
+    new_erc20 = insert(:polyjuice_contract_account, contract_code: sample_erc20.contract_code)
+
+    %{
+      sample_smart_contract: sample_smart_contract,
+      new_erc20: new_erc20
+    }
+  end
+
+  test "check contract is erc20", %{
+    sample_smart_contract: sample_smart_contract,
+    new_erc20: new_erc20
+  } do
+    with_mock MetadataRetriever,
+      get_functions_of: fn _address ->
+        %{decimal: 18, name: "ETH", supply: 1_009_100_000_000_000, symbol: "ETH"}
+      end do
+      CheckContractUDT.perform(%Oban.Job{
+        args: %{"address" => new_erc20.eth_address |> to_string()}
+      })
+
+      udt = Repo.get_by(UDT, id: new_erc20.id)
+      assert udt != nil
+      sc = Repo.get_by(SmartContract, account_id: new_erc20.id)
+      assert sc.abi == sample_smart_contract.abi
+    end
+  end
+
+  test "check contract is not udt" do
+    assert UDT |> Repo.aggregate(:count) == 1
+
+    CheckContractUDT.perform(%Oban.Job{
+      args: %{"address" => "0xc806a37164860913fbff8d013986229724d6c418"}
+    })
+
+    assert UDT |> Repo.aggregate(:count) == 1
+  end
+end


### PR DESCRIPTION
## What problem does this PR solve?
When a new contract deployed, we can verify it is a udt or not.
For erc20, read the contract method of name,symbol, total_supply, decimal.
For erc721 and erc1155, then stand by [erc165](https://eips.ethereum.org/EIPS/eip-165) interface.
At last, compare with exist contract code and create smart contract if possibly.
## Check List
#### Test
- unit test
#### Task
 - none
