### PR TITLE
Fix: fix call transactions with script hash input field raise error

### DIFF
--- a/lib/godwoken_explorer/account.ex
+++ b/lib/godwoken_explorer/account.ex
@@ -13,7 +13,6 @@ defmodule GodwokenExplorer.Account do
     ]
 
   require Logger
-
   alias GodwokenRPC
   alias GodwokenExplorer.Chain.Events.Publisher
   alias GodwokenExplorer.Counters.{AddressTokenTransfersCounter, AddressTransactionsCounter}
@@ -69,6 +68,16 @@ defmodule GodwokenExplorer.Account do
       :contract_code
     ])
     |> validate_required([:id])
+  end
+
+  def get_account_by_address(address) do
+    case address.byte_count do
+      32 ->
+        Repo.get_by(Account, script_hash: address)
+
+      20 ->
+        Repo.get_by(Account, eth_address: address)
+    end
   end
 
   def create_or_update_account!(attrs) do

--- a/lib/godwoken_explorer/graphql/resolovers/transaction.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/transaction.ex
@@ -139,15 +139,15 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
     |> process_from_to_account(input, from_account, to_account)
   end
 
-  defp process_from_to_account({:error, _} = error, _, _, _), do: error
-
   defp process_from_to_account(query, input, from_account, to_account) do
     case {from_account, to_account} do
       {:not_found, _} ->
-        {:error, :not_found}
+        query
+        |> where([t], false)
 
       {_, :not_found} ->
-        {:error, :not_found}
+        query
+        |> where([t], false)
 
       {nil, nil} ->
         query
@@ -190,8 +190,6 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
         end
     end
   end
-
-  defp query_with_block_range({:error, _} = error, _input), do: error
 
   defp query_with_block_range(query, input) do
     start_block_number = Map.get(input, :start_block_number)

--- a/lib/godwoken_explorer/graphql/resolovers/transaction.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/transaction.ex
@@ -99,7 +99,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
           p
 
         {from_address, nil} ->
-          from_account = Repo.get_by(Account, eth_address: from_address)
+          from_account = Account.get_account_by_address(from_address)
 
           if from_account do
             {from_account, nil}
@@ -108,7 +108,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
           end
 
         {nil, to_address} ->
-          to_account = Repo.get_by(Account, eth_address: to_address)
+          to_account = Account.get_account_by_address(to_address)
 
           if to_account do
             {nil, to_account}
@@ -117,8 +117,8 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Transaction do
           end
 
         {from_address, to_address} ->
-          from_account = Repo.get_by(Account, eth_address: from_address)
-          to_account = Repo.get_by(Account, eth_address: to_address)
+          from_account = Account.get_account_by_address(from_address)
+          to_account = Account.get_account_by_address(to_address)
 
           case {from_account, to_account} do
             {nil, nil} ->


### PR DESCRIPTION
## What problem does this PR solve?
issue link: #1102
fix transactions query with script hash input fields which cause by mapping error fields 
## Check List
1. check transaction api with from/to script hash
2. check transaction api with from/to eth hash

#### Test
- unit test
#### Task
 - none
