### PR TITLE
Fix: fix cursor pagination with first page not fillfull error if it has enough data

### DIFF
--- a/lib/godwoken_explorer/graphql/resolovers/common.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/common.ex
@@ -107,7 +107,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Common do
   def maybe_first_page(first_result, query, input, params) do
     limit = input[:limit]
 
-    if first_result.metadata.total_count < limit do
+    if length(first_result.entries) < limit do
       input = Map.delete(input, :before)
 
       paginate_query(

--- a/lib/godwoken_explorer/graphql/resolovers/common.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/common.ex
@@ -42,10 +42,14 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Common do
 
   def paginate_query({:error, _} = error, _, _), do: error
 
-  def paginate_query(query, input, %{
-        cursor_fields: cursor_fields,
-        total_count_primary_key_field: total_count_primary_key_field
-      }) do
+  def paginate_query(
+        query,
+        input,
+        %{
+          cursor_fields: cursor_fields,
+          total_count_primary_key_field: total_count_primary_key_field
+        } = params
+      ) do
     limit = input[:limit]
 
     case {input[:before], input[:after]} do
@@ -67,13 +71,16 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Common do
         )
 
       {query_before, nil} ->
-        Repo.graphql_paginate(
-          query,
-          before: query_before,
-          cursor_fields: cursor_fields,
-          total_count_primary_key_field: total_count_primary_key_field,
-          limit: limit
-        )
+        result =
+          Repo.graphql_paginate(
+            query,
+            before: query_before,
+            cursor_fields: cursor_fields,
+            total_count_primary_key_field: total_count_primary_key_field,
+            limit: limit
+          )
+
+        maybe_first_page(result, query, input, params)
 
       _ ->
         {:error, "before and after both exist"}
@@ -95,5 +102,21 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Common do
         total_count_primary_key_field: :id
       }
     )
+  end
+
+  def maybe_first_page(first_result, query, input, params) do
+    limit = input[:limit]
+
+    if first_result.metadata.total_count < limit do
+      input = Map.delete(input, :before)
+
+      paginate_query(
+        query,
+        input,
+        params
+      )
+    else
+      first_result
+    end
   end
 end

--- a/lib/godwoken_explorer/graphql/resolovers/udt.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/udt.ex
@@ -111,9 +111,9 @@ defmodule GodwokenExplorer.Graphql.Resolvers.UDT do
       [cu],
       cu.address_hash == ^user_address
     )
-    |> order_by([c], desc: :block_number, desc: :value_fetched_at)
+    |> order_by([c], desc: :block_number, desc: :updated_at, desc: :id)
     |> paginate_query(input, %{
-      cursor_fields: [block_number: :desc, value_fetched_at: :desc],
+      cursor_fields: [block_number: :desc, updated_at: :desc, id: :desc],
       total_count_primary_key_field: :id
     })
   end

--- a/test/factories/current_udt_balance_factory.ex
+++ b/test/factories/current_udt_balance_factory.ex
@@ -7,7 +7,7 @@ defmodule GodwokenExplorer.CurrentUDTBalanceFactory do
         %CurrentUDTBalance{
           address_hash: address_hash(),
           token_contract_address_hash: address_hash(),
-          block_number: 1,
+          block_number: block_number(),
           value: Enum.random(1..100_000)
         }
       end

--- a/test/factories/token_transfer_factory.ex
+++ b/test/factories/token_transfer_factory.ex
@@ -19,6 +19,54 @@ defmodule GodwokenExplorer.TokenTransferFactory do
           transaction: build(:transaction)
         }
       end
+
+      def token_transfer_erc1155_inserted_factory do
+        %TokenTransfer{
+          amount: D.new(1_709_736_523_257_224_194),
+          amounts: nil,
+          block: insert(:block),
+          block_number: block_number(),
+          from_address_hash: "0x297ce8d1532704f7be447bc897ab63563d60f223",
+          log_index: 3,
+          to_address_hash: "0xf00b259ed79bb80291b45a76b13e3d71d4869433",
+          token_contract_address_hash: "0xb02c930c2825a960a50ba4ab005e8264498b64a0",
+          token_id: nil,
+          token_ids: [1, 2],
+          transaction: insert(:transaction)
+        }
+      end
+
+      def token_transfer_erc721_inserted_factory do
+        %TokenTransfer{
+          amount: D.new(1_709_736_523_257_224_194),
+          amounts: nil,
+          block: insert(:block),
+          block_number: block_number(),
+          from_address_hash: "0x297ce8d1532704f7be447bc897ab63563d60f223",
+          log_index: 3,
+          to_address_hash: "0xf00b259ed79bb80291b45a76b13e3d71d4869433",
+          token_contract_address_hash: "0xb02c930c2825a960a50ba4ab005e8264498b64a0",
+          token_id: 1,
+          token_ids: nil,
+          transaction: insert(:transaction)
+        }
+      end
+
+      def token_transfer_erc20_inserted_factory do
+        %TokenTransfer{
+          amount: D.new(1_709_736_523_257_224_194),
+          amounts: nil,
+          block: insert(:block),
+          block_number: block_number(),
+          from_address_hash: "0x297ce8d1532704f7be447bc897ab63563d60f223",
+          log_index: 3,
+          to_address_hash: "0xf00b259ed79bb80291b45a76b13e3d71d4869433",
+          token_contract_address_hash: "0xb02c930c2825a960a50ba4ab005e8264498b64a0",
+          token_id: nil,
+          token_ids: nil,
+          transaction: insert(:transaction)
+        }
+      end
     end
   end
 end

--- a/test/graphql/token_approvals_test.exs
+++ b/test/graphql/token_approvals_test.exs
@@ -24,7 +24,7 @@ defmodule GodwokenExplorer.Graphql.TokenApprovalsTest do
         block_number: block.number
       )
 
-    %{approval: approval, approval_all: approval_all, block: block, erc20: erc20}
+    %{approval: approval, approval_all: approval_all, block: block, erc20: erc20, user: user}
   end
 
   test "graphql: token_approvals ", %{
@@ -97,5 +97,183 @@ defmodule GodwokenExplorer.Graphql.TokenApprovalsTest do
                  }
                }
              }
+  end
+
+  test "graphql: token_approvals with first page check ", %{
+    conn: conn,
+    user: user,
+    erc20: erc20
+  } do
+    address = user.eth_address |> to_string()
+
+    for _ <- 1..3 do
+      insert(:approval_token_approval,
+        token_owner_address_hash: user.eth_address,
+        token_contract_address_hash: erc20.contract_address_hash
+      )
+    end
+
+    query = """
+    query {
+     token_approvals(
+        input: {
+          address: "#{address}"
+          token_type: ERC20
+          limit: 2
+          sorter: [
+            { sort_type: DESC, sort_value: BLOCK_NUMBER },
+            { sort_type: DESC, sort_value: ID }
+          ]
+        }
+     ) {
+        entries {
+          transaction_hash
+          block_number
+        }
+
+        metadata {
+          total_count
+          before
+          after
+        }
+      }
+    }
+    """
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "token_approvals" => %{
+          "metadata" => %{
+            "after" => after_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query = token_approvals_with_first_page_query(address, after_value: after_value)
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "token_approvals" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    %{block_number: newest_block_number} =
+      insert(:approval_token_approval,
+        token_owner_address_hash: user.eth_address,
+        token_contract_address_hash: erc20.contract_address_hash
+      )
+
+    query = token_approvals_with_first_page_query(address, before_value: before_value)
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "token_approvals" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query = token_approvals_with_first_page_query(address, before_value: before_value)
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "token_approvals" => %{
+          "entries" => [%{"block_number" => ^newest_block_number} | _] = entries
+        }
+      }
+    } = json_response(conn, 200)
+
+    assert length(entries) == 2
+  end
+
+  defp token_approvals_with_first_page_query(address, before_value: before_value) do
+    """
+    query {
+     token_approvals(
+        input: {
+          before: "#{before_value}"
+          address: "#{address}"
+          token_type: ERC20
+          limit: 2
+          sorter: [
+            { sort_type: DESC, sort_value: BLOCK_NUMBER },
+            { sort_type: DESC, sort_value: ID }
+          ]
+        }
+     ) {
+        entries {
+          transaction_hash
+          block_number
+        }
+
+        metadata {
+          total_count
+          before
+          after
+        }
+      }
+    }
+    """
+  end
+
+  defp token_approvals_with_first_page_query(address, after_value: after_value) do
+    """
+    query {
+     token_approvals(
+        input: {
+          after: "#{after_value}"
+          address: "#{address}"
+          token_type: ERC20
+          limit: 2
+          sorter: [
+            { sort_type: DESC, sort_value: BLOCK_NUMBER },
+            { sort_type: DESC, sort_value: ID }
+          ]
+        }
+     ) {
+        entries {
+          transaction_hash
+          block_number
+        }
+
+        metadata {
+          total_count
+          before
+          after
+        }
+      }
+    }
+    """
   end
 end

--- a/test/graphql/udt_test.exs
+++ b/test/graphql/udt_test.exs
@@ -1164,6 +1164,142 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
            )
   end
 
+  test "graphql: erc721_holders with first page check ", %{
+    conn: conn,
+    erc721_native_udt: erc721_native_udt
+  } do
+    contract_address = erc721_native_udt.contract_address_hash |> to_string()
+    query = erc721_holders_with_first_page_check_base_query(contract_address, "")
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_holders" => %{
+          "metadata" => %{
+            "after" => after_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc721_holders_with_first_page_check_base_query(
+        contract_address,
+        "after: \"#{after_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_holders" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    %{address_hash: address_hash} =
+      insert(:current_udt_balance,
+        token_contract_address_hash: contract_address,
+        token_id: 100,
+        value: 1,
+        token_type: :erc721
+      )
+
+    for index <- 1..2 do
+      insert(:current_udt_balance,
+        address_hash: address_hash,
+        token_contract_address_hash: contract_address,
+        token_id: 100 + index,
+        # this  value means holder's latest quantify of token
+        value: 1 + index,
+        token_type: :erc721
+      )
+    end
+
+    query =
+      erc721_holders_with_first_page_check_base_query(
+        contract_address,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_holders" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc721_holders_with_first_page_check_base_query(
+        contract_address,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_holders" => %{
+          "entries" => [%{"quantity" => "3"} | _] = entries
+        }
+      }
+    } = json_response(conn, 200)
+
+    assert length(entries) == 2
+  end
+
+  defp erc721_holders_with_first_page_check_base_query(contract_address, before_or_after)
+       when is_bitstring(contract_address) do
+    """
+    query {
+      erc721_holders(
+        input: {
+          limit: 2,
+          contract_address: "#{contract_address}",
+          #{before_or_after}
+        }
+      ) {
+        entries {
+          rank
+          address_hash
+          token_contract_address_hash
+          quantity
+        }
+        metadata {
+          total_count
+          after
+          before
+        }
+      }
+    }
+    """
+  end
+
   test "graphql: erc721_holders with pagination", %{
     conn: conn,
     user: user,
@@ -1226,7 +1362,7 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
     query = """
     query {
       erc721_holders(
-        input: { after: "#{after_value}" limit: 1, contract_address: "#{contract_address}"}
+        input: { after: "#{after_value}", limit: 1, contract_address: "#{contract_address}"}
       ) {
         entries {
           rank
@@ -1323,6 +1459,142 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
              },
              json_response(conn, 200)
            )
+  end
+
+  test "graphql: erc1155_holders with first page check ", %{
+    conn: conn,
+    erc1155_native_udt: erc1155_native_udt
+  } do
+    contract_address = erc1155_native_udt.contract_address_hash |> to_string()
+    query = erc1155_holders_with_first_page_check_base_query(contract_address, "")
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_holders" => %{
+          "metadata" => %{
+            "after" => after_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc1155_holders_with_first_page_check_base_query(
+        contract_address,
+        "after: \"#{after_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_holders" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    %{address_hash: address_hash} =
+      insert(:current_udt_balance,
+        token_contract_address_hash: contract_address,
+        token_id: 100,
+        value: 100,
+        token_type: :erc1155
+      )
+
+    for index <- 1..2 do
+      insert(:current_udt_balance,
+        address_hash: address_hash,
+        token_contract_address_hash: contract_address,
+        token_id: 100 + index,
+        # this  value means holder's latest quantify of token
+        value: 100 + index,
+        token_type: :erc1155
+      )
+    end
+
+    query =
+      erc1155_holders_with_first_page_check_base_query(
+        contract_address,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_holders" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc1155_holders_with_first_page_check_base_query(
+        contract_address,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_holders" => %{
+          "entries" => [%{"quantity" => "303"} | _] = entries
+        }
+      }
+    } = json_response(conn, 200)
+
+    assert length(entries) == 2
+  end
+
+  defp erc1155_holders_with_first_page_check_base_query(contract_address, before_or_after)
+       when is_bitstring(contract_address) do
+    """
+    query {
+      erc1155_holders(
+        input: {
+          limit: 2,
+          contract_address: "#{contract_address}",
+          #{before_or_after}
+        }
+      ) {
+        entries {
+          rank
+          address_hash
+          token_contract_address_hash
+          quantity
+        }
+        metadata {
+          total_count
+          after
+          before
+        }
+      }
+    }
+    """
   end
 
   test "graphql: erc1155_holders with token_id", %{

--- a/test/graphql/udt_test.exs
+++ b/test/graphql/udt_test.exs
@@ -1975,6 +1975,143 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
            )
   end
 
+  test "graphql: erc721_inventory with first page check", %{
+    conn: conn,
+    erc721_native_udt: erc721_native_udt
+  } do
+    contract_address_hash = erc721_native_udt.contract_address_hash |> to_string()
+
+    query = erc721_inventory_first_page_check_query_base(contract_address_hash, "")
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_inventory" => %{
+          "metadata" => %{
+            "after" => after_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc721_inventory_first_page_check_query_base(
+        contract_address_hash,
+        "after: \"#{after_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_inventory" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    # add more one
+    _ =
+      insert(:current_udt_balance,
+        token_contract_address_hash: contract_address_hash,
+        token_id: 100,
+        value: 1,
+        token_type: :erc721
+      )
+
+    query =
+      erc721_inventory_first_page_check_query_base(
+        contract_address_hash,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_inventory" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc721_inventory_first_page_check_query_base(
+        contract_address_hash,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc721_inventory" => %{
+          "entries" =>
+            [
+              %{
+                "token_id" => "100"
+              }
+              | _
+            ] = entries
+        }
+      }
+    } = json_response(conn, 200)
+
+    assert length(entries) == 2
+  end
+
+  defp erc721_inventory_first_page_check_query_base(contract_address, before_or_after) do
+    """
+    query {
+      erc721_inventory(
+        input: {
+          limit: 2,
+          contract_address: "#{contract_address}",
+          #{before_or_after}
+        }
+      ) {
+        entries {
+          address_hash
+          token_contract_address_hash
+          token_id
+          token_type
+          counts
+          token_instance {
+            token_contract_address_hash
+            metadata
+          }
+        }
+        metadata {
+          total_count
+          after
+          before
+        }
+      }
+    }
+    """
+  end
+
   test "graphql: erc1155_user_inventory", %{
     conn: conn,
     # user: user
@@ -2061,6 +2198,137 @@ defmodule GodwokenExplorer.Graphql.UDTTest do
              },
              json_response(conn, 200)
            )
+  end
+
+  test "graphql: erc1155_inventory with first page check", %{
+    conn: conn,
+    erc1155_native_udt: erc1155_native_udt
+  } do
+    contract_address_hash = erc1155_native_udt.contract_address_hash |> to_string()
+
+    query = erc1155_inventory_first_page_check_query_base(contract_address_hash, "")
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_inventory" => %{
+          "metadata" => %{
+            "after" => after_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc1155_inventory_first_page_check_query_base(
+        contract_address_hash,
+        "after: \"#{after_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_inventory" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    # add more one
+    _ =
+      insert(:current_udt_balance,
+        token_contract_address_hash: contract_address_hash,
+        token_id: 100,
+        value: 1000,
+        token_type: :erc1155
+      )
+
+    query =
+      erc1155_inventory_first_page_check_query_base(
+        contract_address_hash,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_inventory" => %{
+          "metadata" => %{
+            "before" => before_value
+          }
+        }
+      }
+    } = json_response(conn, 200)
+
+    query =
+      erc1155_inventory_first_page_check_query_base(
+        contract_address_hash,
+        "before: \"#{before_value}\""
+      )
+
+    conn =
+      post(conn, "/graphql", %{
+        "query" => query,
+        "variables" => %{}
+      })
+
+    %{
+      "data" => %{
+        "erc1155_inventory" => %{
+          "entries" =>
+            [
+              %{
+                "counts" => "1000"
+              }
+              | _
+            ] = entries
+        }
+      }
+    } = json_response(conn, 200)
+
+    assert length(entries) == 2
+  end
+
+  defp erc1155_inventory_first_page_check_query_base(contract_address, before_or_after) do
+    """
+    query {
+      erc1155_inventory(
+        input: {
+          contract_address: "#{contract_address}",
+          limit: 2,
+          #{before_or_after}
+        }
+      ) {
+        entries {
+          contract_address_hash
+          token_id
+          counts
+        }
+        metadata {
+          total_count
+          after
+          before
+        }
+      }
+    }
+    """
   end
 
   test "graphql: erc1155_inventory with paginator", %{


### PR DESCRIPTION
## What problem does this PR solve?
link: #993
fix cursor pagination with first page not fillfull error if it has enough data
## Check List
- transactions with pagination
- smart_contracts with pagination
- token_approvals with pagination
- erc20/erc721/erc1155 token_transfers with pagination
- user_erc721_asserts/user_erc1155_asserts with pagination
- udts/erc721udts/erc1155udts with pagination
- erc721holders/erc1155holders with pagination
- erc721inventory/erc1155inventory with pagination
- erc1155userinventory with pagination

#### Unit Test
- [x] transactions api
- [x] smart_contracts api
- [x] token_approvals api
- [x] erc20/erc721/erc1155 token_transfers api
- [x] user_erc721_assets/user_erc1155_assets api
- [x] udts/erc721udts/erc1155udts
- [x] erc721holders/erc1155holders
- [x] erc721inventory/erc1155inventory 
- [x] erc1155userinventory 
#### Task
 - none
