### PR TITLE
feat: set timeout infinity to avoid query timeout

### DIFF
--- a/lib/godwoken_explorer/block.ex
+++ b/lib/godwoken_explorer/block.ex
@@ -182,7 +182,7 @@ defmodule GodwokenExplorer.Block do
         where: b.number <= ^latest_finalized_block_number and b.status == :committed
       )
 
-    updated_blocks = block_query |> Repo.all()
+    updated_blocks = block_query |> Repo.all(timeout: :infinity)
 
     {updated_blocks_number, nil} =
       block_query


### PR DESCRIPTION
## What problem does this PR solve?
Query blocks table often timeout.So add option to avoid it.
## Check List
#### Test
- none
#### Task
 - none
