### PR TITLE
fix: when cache transactions length not 10, also display

### DIFF
--- a/lib/godwoken_explorer/transaction.ex
+++ b/lib/godwoken_explorer/transaction.ex
@@ -120,7 +120,7 @@ defmodule GodwokenExplorer.Transaction do
   # TODO: from and to may can refactor to be a single method
   def latest_10_records do
     case Transactions.all() do
-      txs when is_list(txs) and length(txs) == 10 ->
+      txs when is_list(txs) and txs != [] ->
         txs
         |> Enum.map(fn t ->
           t


### PR DESCRIPTION
## What problem does this PR solve?
For a new deploy, the cache transaction is not 10 length, we needs to return else.Otherwise the api is pending.
## Check List
#### Test
- unit test
#### Task
 - none
