### PR TITLE
feat: hanle eoa transfer to contract account

### DIFF
--- a/lib/godwoken_explorer/account.ex
+++ b/lib/godwoken_explorer/account.ex
@@ -777,6 +777,16 @@ defmodule GodwokenExplorer.Account do
     end)
   end
 
+  # zero nonce eoa user can transfer to contract account, so clear eoa user eth_address to keep uniq eth_address
+  def handle_eoa_to_contract(eth_address) do
+    accounts = from(a in Account, where: a.eth_address == ^eth_address) |> Repo.all()
+
+    if length(accounts) == 2 do
+      eoa = accounts |> Enum.filter(fn a -> a.type == :eth_user end) |> List.first()
+      Account.changeset(eoa, %{eth_address: nil, registry_address: nil}) |> Repo.update()
+    end
+  end
+
   defp rpc() do
     Application.get_env(:godwoken_explorer, :rpc_module, GodwokenRPC)
   end

--- a/lib/godwoken_indexer/worker/import_contract_code.ex
+++ b/lib/godwoken_indexer/worker/import_contract_code.ex
@@ -11,6 +11,8 @@ defmodule GodwokenIndexer.Worker.ImportContractCode do
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"block_number" => block_number, "address" => address}}) do
+    Account.handle_eoa_to_contract(address)
+
     {:ok,
      %{
        errors: [],

--- a/lib/godwoken_indexer/worker/sourcify.ex
+++ b/lib/godwoken_indexer/worker/sourcify.ex
@@ -1,9 +1,13 @@
 defmodule GodwokenIndexer.Worker.Sourcify do
-  alias GodwokenExplorer.Graphql.Sourcify
-
   use Oban.Worker, queue: :default, unique: [period: :infinity, states: Oban.Job.states()]
+
+  alias GodwokenExplorer.Graphql.Sourcify
+  alias GodwokenExplorer.Account
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"eth_address" => eth_address}}) do
+    Account.handle_eoa_to_contract(eth_address)
+
     Sourcify.verify_and_update_from_sourcify(eth_address)
     :ok
   end

--- a/test/godwoken_explorer/account_test.exs
+++ b/test/godwoken_explorer/account_test.exs
@@ -106,4 +106,21 @@ defmodule GodwokenExplorer.AccountTest do
              ) == {:ok, Repo.get(Account, 48250)}
     end
   end
+
+  test "handle eoa to contract" do
+    eoa =
+      insert(:user, registry_address: "0x0200000014000000c3dc7b0ea12a45830e89326dde9f2dadce0dbc5d")
+
+    contract =
+      insert(:polyjuice_contract_account,
+        eth_address: eoa.eth_address,
+        registry_address: "0x0200000014000000c3dc7b0ea12a45830e89326dde9f2dadce0dbc5d"
+      )
+
+    Account.handle_eoa_to_contract(eoa.eth_address)
+    assert eoa |> Repo.reload!() |> Map.get(:eth_address) == nil
+    assert eoa |> Repo.reload!() |> Map.get(:registry_address) == nil
+    assert contract |> Repo.reload!() |> Map.get(:eth_address) != nil
+    assert contract |> Repo.reload!() |> Map.get(:registry_address) != nil
+  end
 end


### PR DESCRIPTION
## What problem does this PR solve?
Zero nonce eoa user can transfer to contract account in godwoken, but contract account use eoa user's eth_address.We need to keep uniq eth_address in our database, so remove eoa user's eth_address when we found this situation.
## Check List
#### Test
- unit test
#### Task
 - none
