### PR TITLE
feat: add bit_alias batch api

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -102,7 +102,7 @@ config :godwoken_explorer,
       "homestead,tangerineWhistle,spuriousDragon,byzantium,constantinople,petersburg,istanbul,berlin,london,default",
   solc_bin_api_url: "https://solc-bin.ethereum.org"
 
-config :tesla, :adapter, {Tesla.Adapter.Finch, name: MyFinch}
+config :tesla, :adapter, Tesla.Adapter.Mint
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -102,6 +102,8 @@ config :godwoken_explorer,
       "homestead,tangerineWhistle,spuriousDragon,byzantium,constantinople,petersburg,istanbul,berlin,london,default",
   solc_bin_api_url: "https://solc-bin.ethereum.org"
 
+config :tesla, :adapter, {Tesla.Adapter.Finch, name: MyFinch}
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/godwoken_explorer/application.ex
+++ b/lib/godwoken_explorer/application.ex
@@ -11,6 +11,7 @@ defmodule GodwokenExplorer.Application do
       GodwokenExplorer.Chain.Cache.Blocks,
       GodwokenExplorer.Chain.Cache.Transactions,
       GodwokenExplorer.ETS.SmartContracts,
+      {Finch, name: MyFinch},
       {Oban, oban_config()}
     ]
 

--- a/lib/godwoken_explorer/application.ex
+++ b/lib/godwoken_explorer/application.ex
@@ -11,7 +11,6 @@ defmodule GodwokenExplorer.Application do
       GodwokenExplorer.Chain.Cache.Blocks,
       GodwokenExplorer.Chain.Cache.Transactions,
       GodwokenExplorer.ETS.SmartContracts,
-      {Finch, name: MyFinch},
       {Oban, oban_config()}
     ]
 

--- a/lib/godwoken_explorer/bit/api.ex
+++ b/lib/godwoken_explorer/bit/api.ex
@@ -114,9 +114,7 @@ defmodule GodwokenExplorer.Bit.API do
   end
 
   def fetch_reverse_record_info(address) do
-    url = "#{base_url()}/v1/reverse/record"
-
-    request = %{
+    params = %{
       type: "blockchain",
       key_info: %{
         # 60: ETH, 195: TRX, 9006: BNB, 966: Matic
@@ -127,56 +125,28 @@ defmodule GodwokenExplorer.Bit.API do
       }
     }
 
-    case HTTPoison.post(url, Jason.encode_to_iodata!(request), [
-           {"Content-Type", "application/json"}
-         ]) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        case Jason.decode!(body) do
-          %{
-            "data" => %{"account" => _, "account_alias" => account_alias},
-            "errno" => 0,
-            "errmsg" => ""
-          } ->
-            {:ok, account_alias}
-
-          %{"data" => _data, "errno" => errno, "errmsg" => errmsg} ->
-            Logger.error("Fetch #{address} account alias failed.#{errno}: #{errmsg}")
-            {:error, nil}
-        end
-
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.error("Fetch #{address} account alias failed.reason: #{reason}")
-        {:error, nil}
+    with {:ok, %{body: body}} <- post("/v1/reverse/record", params),
+         %{"data" => %{"account_alias" => account_alias}} when not is_nil(account_alias) <- body do
+      {:ok, account_alias}
+    else
+      error ->
+        {:error, "error with #{inspect(error)}"}
     end
   end
 
   def fetch_address_by_alias(bit_alias) do
-    url = "#{base_url()}/v1/account/info"
-
-    request = %{
+    params = %{
       account: bit_alias
     }
 
-    case HTTPoison.post(url, Jason.encode_to_iodata!(request), [
-           {"Content-Type", "application/json"}
-         ]) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        case Jason.decode!(body) do
-          %{
-            "data" => %{"out_point" => _, "account_info" => %{"owner_key" => address}},
-            "errno" => 0,
-            "errmsg" => ""
-          } ->
-            {:ok, address}
-
-          %{"data" => _data, "errno" => errno, "errmsg" => errmsg} ->
-            Logger.error("Fetch #{bit_alias} address failed.#{errno}: #{errmsg}")
-            {:error, nil}
-        end
-
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.error("Fetch #{bit_alias} address failed.reason: #{reason}")
-        {:error, nil}
+    with {:ok, %{body: body}} <- post("/v2/account/records", params),
+         %{"data" => %{"records" => records}} when not is_nil(records) <- body,
+         found when not is_nil(found) <- Enum.find(records, fn r -> r["key"] == "address.60" end),
+         {:ok, address} <- Address.cast(found["value"]) do
+      {:ok, address}
+    else
+      error ->
+        {:error, "error with #{inspect(error)}"}
     end
   end
 

--- a/lib/godwoken_explorer/bit/api.ex
+++ b/lib/godwoken_explorer/bit/api.ex
@@ -97,12 +97,12 @@ defmodule GodwokenExplorer.Bit.API do
     if results do
       results
       |> Enum.map(fn r ->
-        case r do
-          %{"account" => bit_alias, "records" => records} ->
-            found = Enum.find(records, fn r -> r["key"] == "address.60" end)
-            {:ok, address} = Address.cast(found["value"])
-            %{bit_alias: bit_alias, address: address}
-
+        with %{"account" => bit_alias, "records" => records} <- r,
+             found when not is_nil(found) <-
+               Enum.find(records, fn r -> r["key"] == "address.60" end),
+             {:ok, address} <- Address.cast(found["value"]) do
+          %{bit_alias: bit_alias, address: address}
+        else
           _ ->
             :skip
         end

--- a/lib/godwoken_explorer/bit/api.ex
+++ b/lib/godwoken_explorer/bit/api.ex
@@ -46,6 +46,7 @@ defmodule GodwokenExplorer.Bit.API do
       {:ok, result}
     else
       error ->
+        Logger.error(fn -> "batch_fetch_aliases_by_addresses with error: #{inspect(error)}" end)
         {:error, "error with #{inspect(error)}"}
     end
   end
@@ -87,7 +88,7 @@ defmodule GodwokenExplorer.Bit.API do
     else
       error ->
         Logger.error(fn -> "batch_fetch_addresses_by_aliases with error: #{inspect(error)}" end)
-        {:error, "internal_error"}
+        {:error, "error with #{inspect(error)}"}
     end
   end
 

--- a/lib/godwoken_explorer/bit/api.ex
+++ b/lib/godwoken_explorer/bit/api.ex
@@ -1,6 +1,106 @@
 defmodule GodwokenExplorer.Bit.API do
   require Logger
 
+  use Tesla, only: [:get, :post], docs: false
+
+  plug(Tesla.Middleware.BaseUrl, base_url())
+  plug(Tesla.Middleware.JSON)
+
+  def batch_fetch_reverse_record_info(addresses) do
+    batch_key_info =
+      addresses
+      |> Enum.map(fn address ->
+        %{
+          type: "blockchain",
+          key_info: %{
+            # 60: ETH, 195: TRX, 9006: BNB, 966: Matic
+            coin_type: "60",
+            # 1: ETH, 56: BSC, 137: Polygon
+            chain_id: "1",
+            key: "#{address}"
+          }
+        }
+      end)
+
+    params = %{
+      "batch_key_info" => batch_key_info
+    }
+
+    with {:ok, %{body: body}} <- post("/v1/batch/reverse/record", params) do
+      returns = process_batch_fetch_reverse_response(body)
+
+      result =
+        Enum.zip(addresses, returns)
+        |> Enum.map(fn {address, bit_alias} -> %{address: address, bit_alias: bit_alias} end)
+
+      {:ok, result}
+    else
+      error ->
+        {:error, "error with #{inspect(error)}"}
+    end
+  end
+
+  defp process_batch_fetch_reverse_response(body) do
+    results = body["data"]["list"]
+
+    if results do
+      results
+      |> Enum.map(fn r ->
+        case r do
+          %{"account" => _account, "account_alias" => account_alias} ->
+            account_alias
+
+          _ ->
+            :skip
+        end
+      end)
+      |> Enum.filter(&(&1 != :skip))
+    else
+      []
+    end
+  end
+
+  def batch_fetch_addresses_by_alias(aliases) do
+    aliases =
+      aliases
+      |> Enum.filter(fn a ->
+        not is_nil(a) and String.contains?(a, ".bit")
+      end)
+
+    params = %{
+      "accounts" => aliases
+    }
+
+    with {:ok, %{body: body}} <- post("/v1/batch/account/records", params) do
+      return = process_batch_fetch_response(body)
+      {:ok, return}
+    else
+      error ->
+        {:error, "error with #{inspect(error)}"}
+    end
+  end
+
+  defp process_batch_fetch_response(body) do
+    results = body["data"]["list"]
+
+    if results do
+      results
+      |> Enum.map(fn r ->
+        case r do
+          %{"account" => bit_alias, "records" => records} ->
+            found = Enum.find(records, fn r -> r["key"] == "address.eth" end)
+            %{bit_alias: bit_alias, address: found["value"]}
+
+          _ ->
+            :skip
+        end
+      end)
+      |> Enum.filter(&(&1 != :skip))
+    else
+      []
+    end
+  end
+
   def fetch_reverse_record_info(address) do
     url = "#{base_url()}/v1/reverse/record"
 

--- a/lib/godwoken_explorer/graphql/resolovers/search.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/search.ex
@@ -80,6 +80,18 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Search do
     end
   end
 
+  def batch_fetch_addresses_by_aliases(_parent, %{input: input} = _args, _resolution) do
+    bit_aliases = Map.get(input, :bit_aliases)
+
+    BitApi.batch_fetch_addresses_by_aliases(bit_aliases)
+  end
+
+  def batch_fetch_aliases_by_addresses(_parent, %{input: input} = _args, _resolution) do
+    addresses = Map.get(input, :addresses)
+
+    BitApi.batch_fetch_aliases_by_addresses(addresses)
+  end
+
   defp search_udt_condition(query, input) do
     fuzzy_name = Map.get(input, :fuzzy_name)
     contract_address = Map.get(input, :contract_address)

--- a/lib/godwoken_explorer/graphql/resolovers/search.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/search.ex
@@ -68,7 +68,10 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Search do
     bit_alias = Map.get(input, :bit_alias)
 
     if String.ends_with?(bit_alias, ".bit") do
-      BitApi.fetch_address_by_alias(bit_alias)
+      case BitApi.fetch_address_by_alias(bit_alias) do
+        {:ok, _} = r -> r
+        _ -> {:ok, nil}
+      end
     else
       {:error, "input bit alias wrong format"}
     end
@@ -76,7 +79,11 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Search do
 
   def reverse_search_bit_alias(_parent, %{input: input} = _args, _resolution) do
     address = Map.get(input, :address)
-    BitApi.fetch_reverse_record_info(address)
+
+    case BitApi.fetch_reverse_record_info(address) do
+      {:ok, _} = r -> r
+      _ -> {:ok, nil}
+    end
   end
 
   def batch_fetch_addresses_by_aliases(_parent, %{input: input} = _args, _resolution) do

--- a/lib/godwoken_explorer/graphql/resolovers/search.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/search.ex
@@ -80,6 +80,11 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Search do
     end
   end
 
+  def reverse_search_bit_alias(_parent, %{input: input} = _args, _resolution) do
+    address = Map.get(input, :address)
+    BitApi.fetch_reverse_record_info(address)
+  end
+
   def batch_fetch_addresses_by_aliases(_parent, %{input: input} = _args, _resolution) do
     bit_aliases = Map.get(input, :bit_aliases)
 

--- a/lib/godwoken_explorer/graphql/resolovers/search.ex
+++ b/lib/godwoken_explorer/graphql/resolovers/search.ex
@@ -68,13 +68,7 @@ defmodule GodwokenExplorer.Graphql.Resolvers.Search do
     bit_alias = Map.get(input, :bit_alias)
 
     if String.ends_with?(bit_alias, ".bit") do
-      address =
-        case BitApi.fetch_address_by_alias(bit_alias) do
-          {:ok, address} -> address
-          {:error, nil} -> nil
-        end
-
-      {:ok, address}
+      BitApi.fetch_address_by_alias(bit_alias)
     else
       {:error, "input bit alias wrong format"}
     end

--- a/lib/godwoken_explorer/graphql/types/search.ex
+++ b/lib/godwoken_explorer/graphql/types/search.ex
@@ -93,6 +93,29 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
 
     @desc """
     ```graphql
+    query {
+      reverse_search_bit_alias(
+        input: {
+          address: "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+        }
+      )
+    }
+    ```
+    ```json
+    {
+      "data": {
+        "reverse_search_bit_alias": "freder.bit"
+      }
+    }
+    ```
+    """
+    field :reverse_search_bit_alias, :string do
+      arg(:input, non_null(:reverse_search_bit_alias_input))
+      resolve(&Resolvers.Search.reverse_search_bit_alias/3)
+    end
+
+    @desc """
+    ```graphql
     query{
       batch_fetch_addresses_by_aliases(
         input: {
@@ -183,6 +206,10 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
 
   input_object :search_bit_alias_input do
     field(:bit_alias, non_null(:string))
+  end
+
+  input_object :reverse_search_bit_alias_input do
+    field(:address, non_null(:hash_address))
   end
 
   input_object :batch_fetch_addresses_by_alias_input do

--- a/lib/godwoken_explorer/graphql/types/search.ex
+++ b/lib/godwoken_explorer/graphql/types/search.ex
@@ -86,7 +86,7 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
     ```
     """
 
-    field :search_bit_alias, :string do
+    field :search_bit_alias, :hash_address do
       arg(:input, non_null(:search_bit_alias_input))
       resolve(&Resolvers.Search.search_bit_alias/3)
     end

--- a/lib/godwoken_explorer/graphql/types/search.ex
+++ b/lib/godwoken_explorer/graphql/types/search.ex
@@ -68,6 +68,7 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
     end
 
     @desc """
+    ```graphql
     query {
       search_bit_alias(
         input: {
@@ -75,12 +76,14 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
         }
       )
     }
-
+    ```
+    ```json
     {
       "data": {
         "search_bit_alias": "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
       }
     }
+    ```
     """
 
     field :search_bit_alias, :string do
@@ -88,11 +91,41 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
       resolve(&Resolvers.Search.search_bit_alias/3)
     end
 
+    @desc """
+    ```graphql
+    query{
+      batch_fetch_addresses_by_aliases(
+        input: {
+          bit_aliases: ["freder.bit"]
+        }
+      )
+      {
+        address
+        bit_alias
+      }
+    }
+    ```
+    """
     field :batch_fetch_addresses_by_aliases, list_of(:address_bit_alias) do
       arg(:input, non_null(:batch_fetch_addresses_by_alias_input))
       resolve(&Resolvers.Search.batch_fetch_addresses_by_aliases/3)
     end
 
+    @desc """
+    ```graphql
+    query{
+      batch_fetch_aliases_by_addresses(
+        input: {
+          addresses: ["0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"]
+        }
+      )
+      {
+        address
+        bit_alias
+      }
+    }
+    ```
+    """
     field :batch_fetch_aliases_by_addresses, list_of(:address_bit_alias) do
       arg(:input, non_null(:batch_fetch_aliases_by_addresses_input))
       resolve(&Resolvers.Search.batch_fetch_aliases_by_addresses/3)

--- a/lib/godwoken_explorer/graphql/types/search.ex
+++ b/lib/godwoken_explorer/graphql/types/search.ex
@@ -87,6 +87,21 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
       arg(:input, non_null(:search_bit_alias_input))
       resolve(&Resolvers.Search.search_bit_alias/3)
     end
+
+    field :batch_fetch_addresses_by_aliases, list_of(:address_bit_alias) do
+      arg(:input, non_null(:batch_fetch_addresses_by_alias_input))
+      resolve(&Resolvers.Search.batch_fetch_addresses_by_aliases/3)
+    end
+
+    field :batch_fetch_aliases_by_addresses, list_of(:address_bit_alias) do
+      arg(:input, non_null(:batch_fetch_aliases_by_addresses_input))
+      resolve(&Resolvers.Search.batch_fetch_aliases_by_addresses/3)
+    end
+  end
+
+  object :address_bit_alias do
+    field(:address, :hash_address)
+    field(:bit_alias, :string)
   end
 
   object :search_result do
@@ -135,6 +150,14 @@ defmodule GodwokenExplorer.Graphql.Types.Search do
 
   input_object :search_bit_alias_input do
     field(:bit_alias, non_null(:string))
+  end
+
+  input_object :batch_fetch_addresses_by_alias_input do
+    field(:bit_aliases, non_null(list_of(:string)))
+  end
+
+  input_object :batch_fetch_aliases_by_addresses_input do
+    field(:addresses, non_null(list_of(:hash_address)))
   end
 
   input_object :search_keyword_input do

--- a/mix.exs
+++ b/mix.exs
@@ -144,9 +144,13 @@ defmodule GodwokenExplorer.MixProject do
       {:money, "~> 1.9"},
       {:plug_heartbeat, "~> 1.0"},
       {:paginator, "~> 1.1.0"},
-      {:tesla, "~> 1.4"},
       {:quarto, "~> 1.0"},
-      {:constants, "~> 0.1.0"}
+      {:constants, "~> 0.1.0"},
+
+      # http client
+      {:tesla, "~> 1.4"},
+      {:castore, "~> 0.1.0"},
+      {:mint, "~> 1.0"}
     ]
   end
 

--- a/test/godwoken_explorer/bit/api_test.exs
+++ b/test/godwoken_explorer/bit/api_test.exs
@@ -39,28 +39,140 @@ defmodule GodwokenExplorer.Bit.APITest do
   end
 
   test "batch fetch addresses by aliases", %{user: _user} do
-    {:ok, data} =
-      GodwokenExplorer.Bit.API.batch_fetch_addresses_by_aliases([
-        "freder.bit",
-        "magickbase.bit"
-      ])
+    with_mock Tesla,
+      execute: fn _, _, _ ->
+        {:ok,
+         %{
+           body: %{
+             "data" => %{
+               "list" => [
+                 %{
+                   "account" => "freder.bit",
+                   "account_id" => "0x4027ebb00204379b84db0714b9e10f73c1434cbc",
+                   "err_msg" => "",
+                   "records" => [
+                     %{
+                       "key" => "address.60",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" => "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+                     },
+                     %{
+                       "key" => "profile.avatar",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" =>
+                         "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/Flag_of_Argentina.svg/2560px-Flag_of_Argentina.svg.png"
+                     },
+                     %{
+                       "key" => "profile.description",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" =>
+                         "During the epidemic, wear a mask frequently and drink plenty of water to protect yourself and your family."
+                     },
+                     %{
+                       "key" => "profile.github",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" => "FrederLu"
+                     },
+                     %{
+                       "key" => "profile.discord",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" => "981133411190177812"
+                     }
+                   ]
+                 },
+                 %{
+                   "account" => "magickbase.bit",
+                   "account_id" => "0x07d765887d5545b7255b22c8cf49607c054c58f8",
+                   "err_msg" => "",
+                   "records" => [
+                     %{
+                       "key" => "profile.github",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" => "Magickbase"
+                     },
+                     %{
+                       "key" => "profile.discord",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" => "https://discord.gg/N9nZ3JE2Gg"
+                     },
+                     %{
+                       "key" => "profile.avatar",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" => "https://avatars.githubusercontent.com/u/103997195"
+                     },
+                     %{
+                       "key" => "profile.description",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" =>
+                         "As a comprehensive ecosystem that combines powerful decision-making tools, secure blockchain technology, and robust infrastructure, Magickbase is a valuable resource for anyone looking to take control of their data on Nervos CKB and use it in innovative and transformative ways."
+                     },
+                     %{
+                       "key" => "custom_key.kanban",
+                       "label" => "",
+                       "ttl" => "300",
+                       "value" => "https://github.com/orgs/Magickbase/projects/1/views/2"
+                     }
+                   ]
+                 }
+               ]
+             },
+             "errmsg" => "",
+             "errno" => 0
+           }
+         }}
+      end do
+      {:ok, data} =
+        GodwokenExplorer.Bit.API.batch_fetch_addresses_by_aliases([
+          "freder.bit",
+          "magickbase.bit"
+        ])
 
-    assert match?([%{bit_alias: "freder.bit"} | _], data)
+      assert match?([%{bit_alias: "freder.bit"} | _], data)
+    end
   end
 
   test "batch fetch aliases by addresses", %{user: _user} do
-    freder_address = "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
-    hello_address = "0x38401c6364bfd05c45ceefccc3b75e33fa815815"
+    with_mock Tesla,
+      execute: fn _, _, _ ->
+        {:ok,
+         %{
+           body: %{
+             "data" => %{
+               "list" => [
+                 %{
+                   "account" => "freder.bit",
+                   "account_alias" => "freder.bit",
+                   "err_msg" => ""
+                 },
+                 %{
+                   "account" => "mybit.bit",
+                   "account_alias" => "mybit.bit",
+                   "err_msg" => ""
+                 }
+               ]
+             }
+           }
+         }}
+      end do
+      freder_address = "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+      hello_address = "0x38401c6364bfd05c45ceefccc3b75e33fa815815"
 
-    {:ok, freder_address_alias} =
-      GodwokenExplorer.Bit.API.fetch_reverse_record_info(freder_address)
+      {:ok, data} =
+        GodwokenExplorer.Bit.API.batch_fetch_aliases_by_addresses([
+          freder_address,
+          hello_address
+        ])
 
-    {:ok, data} =
-      GodwokenExplorer.Bit.API.batch_fetch_aliases_by_addresses([
-        freder_address,
-        hello_address
-      ])
-
-    assert match?([%{bit_alias: ^freder_address_alias} | _], data)
+      assert match?([%{bit_alias: "freder.bit"} | _], data)
+    end
   end
 end

--- a/test/godwoken_explorer/bit/api_test.exs
+++ b/test/godwoken_explorer/bit/api_test.exs
@@ -38,4 +38,26 @@ defmodule GodwokenExplorer.Bit.APITest do
                {:error, nil}
     end
   end
+
+  test "batch fetch addresses by aliases", %{user: _user} do
+    {:ok, data} =
+      GodwokenExplorer.Bit.API.batch_fetch_addresses_by_aliases([
+        "freder.bit"
+      ])
+
+    assert match?([%{bit_alias: "freder.bit"} | _], data)
+  end
+
+  test "batch fetch aliases by addresses", %{user: _user} do
+    address = "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+
+    {:ok, bit_alias} = GodwokenExplorer.Bit.API.fetch_reverse_record_info(address)
+
+    {:ok, data} =
+      GodwokenExplorer.Bit.API.batch_fetch_aliases_by_addresses([
+        address
+      ])
+
+    assert match?([%{bit_alias: ^bit_alias} | _], data)
+  end
 end

--- a/test/godwoken_explorer/bit/api_test.exs
+++ b/test/godwoken_explorer/bit/api_test.exs
@@ -42,7 +42,8 @@ defmodule GodwokenExplorer.Bit.APITest do
   test "batch fetch addresses by aliases", %{user: _user} do
     {:ok, data} =
       GodwokenExplorer.Bit.API.batch_fetch_addresses_by_aliases([
-        "freder.bit"
+        "freder.bit",
+        "magickbase.bit"
       ])
 
     assert match?([%{bit_alias: "freder.bit"} | _], data)

--- a/test/graphql/search_test.exs
+++ b/test/graphql/search_test.exs
@@ -4,6 +4,8 @@ defmodule GodwokenExplorer.Graphql.SearchTest do
   import GodwokenExplorer.Factory, only: [insert: 1, insert: 2, insert!: 1]
   import Mock
 
+  alias GodwokenExplorer.Chain.Hash.Address
+
   setup do
     for _ <- 1..10 do
       insert(:native_udt, eth_type: :erc721)
@@ -349,6 +351,104 @@ defmodule GodwokenExplorer.Graphql.SearchTest do
                    "search_bit_alias" => "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
                  }
                }
+      end
+    end
+
+    test "batch fetch", %{conn: conn} do
+      query = """
+        query{
+          batch_fetch_addresses_by_aliases(
+            input: {
+              bit_aliases: ["freder.bit"]
+            }
+          )
+          {
+            address
+            bit_alias
+          }
+        }
+      """
+
+      with_mock GodwokenExplorer.Bit.API,
+        batch_fetch_addresses_by_aliases: fn _bit_alias ->
+          address = "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+          {:ok, address} = Address.cast(address)
+
+          {:ok,
+           [
+             %{
+               address: address,
+               bit_alias: "freder.bit"
+             }
+           ]}
+        end do
+        conn =
+          post(conn, "/graphql", %{
+            "query" => query,
+            "variables" => %{}
+          })
+
+        assert match?(
+                 %{
+                   "data" => %{
+                     "batch_fetch_addresses_by_aliases" => [
+                       %{
+                         "address" => "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6",
+                         "bit_alias" => "freder.bit"
+                       }
+                     ]
+                   }
+                 },
+                 json_response(conn, 200)
+               )
+      end
+
+      query = """
+        query{
+          batch_fetch_aliases_by_addresses(
+            input: {
+              addresses: ["0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"]
+            }
+          )
+          {
+            address
+            bit_alias
+          }
+        }
+      """
+
+      with_mock GodwokenExplorer.Bit.API,
+        batch_fetch_aliases_by_addresses: fn _bit_alias ->
+          address = "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+          {:ok, address} = Address.cast(address)
+
+          {:ok,
+           [
+             %{
+               address: address,
+               bit_alias: "freder.bit"
+             }
+           ]}
+        end do
+        conn =
+          post(conn, "/graphql", %{
+            "query" => query,
+            "variables" => %{}
+          })
+
+        assert match?(
+                 %{
+                   "data" => %{
+                     "batch_fetch_aliases_by_addresses" => [
+                       %{
+                         "address" => "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6",
+                         "bit_alias" => "freder.bit"
+                       }
+                     ]
+                   }
+                 },
+                 json_response(conn, 200)
+               )
       end
     end
   end

--- a/test/graphql/search_test.exs
+++ b/test/graphql/search_test.exs
@@ -354,6 +354,33 @@ defmodule GodwokenExplorer.Graphql.SearchTest do
                  }
                }
       end
+
+      query = """
+      query{
+        reverse_search_bit_alias(
+          input: {
+            address: "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+          }
+        )
+      }
+      """
+
+      with_mock GodwokenExplorer.Bit.API,
+        fetch_reverse_record_info: fn _bit_alias ->
+          {:ok, "freder.bit"}
+        end do
+        conn =
+          post(conn, "/graphql", %{
+            "query" => query,
+            "variables" => %{}
+          })
+
+        assert json_response(conn, 200) == %{
+                 "data" => %{
+                   "reverse_search_bit_alias" => "freder.bit"
+                 }
+               }
+      end
     end
 
     test "batch fetch", %{conn: conn} do

--- a/test/graphql/search_test.exs
+++ b/test/graphql/search_test.exs
@@ -338,7 +338,9 @@ defmodule GodwokenExplorer.Graphql.SearchTest do
 
       with_mock GodwokenExplorer.Bit.API,
         fetch_address_by_alias: fn _bit_alias ->
-          {:ok, "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"}
+          address = "0xcc0af0af911dd40853b8c8dfee90b32f8d1ecad6"
+          {:ok, address} = Address.cast(address)
+          {:ok, address}
         end do
         conn =
           post(conn, "/graphql", %{


### PR DESCRIPTION
## What problem does this PR solve?
issue link: #1288 
feat: add batch bit api for search bit_alias mapping address and it's reverse api
## Check List
- search_bit_alias graphql api
- reverse_search_bit_alias graphql api
- batch_fetch_addresses_by_aliases graphql api
- batch_fetch_aliases_by_addresses graphql api
#### Test
- unit test
#### Task
 - none
